### PR TITLE
fix: Lightbox 底部说明 strip 增加可点交互提示 (#8)

### DIFF
--- a/src/islands/SeatViewLightbox.tsx
+++ b/src/islands/SeatViewLightbox.tsx
@@ -5,7 +5,7 @@ import Lightbox, {
 } from "yet-another-react-lightbox";
 import Zoom from "yet-another-react-lightbox/plugins/zoom";
 import "yet-another-react-lightbox/styles.css";
-import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, ChevronUp, X } from "lucide-react";
 import type { Locale } from "@/i18n/config";
 import { useLocale } from "@/hooks/useLocale";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
@@ -349,19 +349,27 @@ function FooterStrip({
         onClick={onOpenDetails}
         aria-label={openDetailsLabel}
         className={cn(
-          "pointer-events-auto max-w-[80%] truncate rounded px-2 py-1 text-left",
-          "bg-[oklch(0.13_0.008_75_/_0.55)] text-[oklch(0.93_0.006_88)]",
-          "text-sm [font-variant-numeric:tabular-nums]",
+          "pointer-events-auto inline-flex max-w-[80%] items-center gap-1.5 rounded-full py-1 pl-2.5 pr-3 text-left",
+          "border border-[oklch(0.8_0.006_86_/_0.25)] bg-[oklch(0.13_0.008_75_/_0.6)] text-[oklch(0.93_0.006_88)]",
+          "text-sm [font-variant-numeric:tabular-nums] transition-colors",
+          "hover:border-[oklch(0.8_0.006_86_/_0.45)] hover:bg-[oklch(0.16_0.008_75_/_0.72)]",
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-[oklch(0.8_0.006_86)] focus:outline-none",
         )}
       >
-        <span className="font-medium">{dto.seatLabel}</span>
-        {date && (
-          <span className="opacity-70">
-            {" · "}
-            {date}
-          </span>
-        )}
+        <ChevronUp
+          className="size-3.5 shrink-0 opacity-80"
+          aria-hidden="true"
+          strokeWidth={1.5}
+        />
+        <span className="min-w-0 truncate">
+          <span className="font-medium">{dto.seatLabel}</span>
+          {date && (
+            <span className="opacity-70">
+              {" · "}
+              {date}
+            </span>
+          )}
+        </span>
       </button>
       {isSequence && position && (
         <span


### PR DESCRIPTION
## Summary
- 在 Lightbox 查看视角图时，底部「座位号 · 日期」按钮原本看起来像静态文字，移动端（无 hover）几乎无法发现它可点开详情（issue #8）。
- `FooterStrip` 增加 `ChevronUp` 上展开图标 + hairline ash 边界 pill + hover 反馈，使其在静止态即读作「可点开」。
- 文字移入 `min-w-0 truncate` span、图标 `shrink-0` 不被裁切；保留原有 `aria-label`/focus-visible。
- 纯展示层改动：未引入朱赤（Lightbox 内禁用强调色）、未新增 i18n、reduced-motion 不受影响、sequence `n/N` 指示未动。

## Test plan
- [x] `npm run typecheck`（astro check）：0 error / 0 warning（85 文件）
- [x] `npx prettier --check`：格式合规
- [ ] 移动端真实浏览器视觉确认（Android Chrome：strip 可见图标 + 边界，点开 DetailSheet 正常）

Closes #8