### PR TITLE
feat: 坐席图标点全屏编辑模式（⤢ 进入 / 缩放 / 撤销 / 确认）(issue #9)

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -100,6 +100,8 @@ const en: Messages = {
       markerLabel: "Your seat marker, drag to adjust",
       undo: "Undo",
       confirm: "Confirm location →",
+      fullscreen: "Mark fullscreen",
+      exitFullscreen: "Exit fullscreen",
       summary: "{label} · {x}% / {y}%",
     },
     step2: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -94,6 +94,8 @@ const ja: Messages = {
       markerLabel: "座席のマーカー、ドラッグで調整できます",
       undo: "取り消す",
       confirm: "位置を確定 →",
+      fullscreen: "全画面で指定",
+      exitFullscreen: "全画面を終了",
       summary: "{label} · {x}% / {y}%",
     },
     step2: {

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -99,6 +99,8 @@ const ko: Messages = {
       markerLabel: "좌석 마커, 드래그해서 조정할 수 있어요",
       undo: "되돌리기",
       confirm: "위치 확정 →",
+      fullscreen: "전체화면 지정",
+      exitFullscreen: "전체화면 종료",
       summary: "{label} · {x}% / {y}%",
     },
     step2: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -105,6 +105,10 @@ export interface Messages {
       markerLabel: string;
       undo: string;
       confirm: string;
+      /** ⤢ open-fullscreen button label / title. */
+      fullscreen: string;
+      /** ✕ exit-fullscreen aria-label. */
+      exitFullscreen: string;
       /** Folded summary, `{label}` → sub-map, `{x}`/`{y}` → percent ints. */
       summary: string;
     };
@@ -493,6 +497,8 @@ const zh: Messages = {
       markerLabel: "你的座位标注点，拖动可调整",
       undo: "撤销",
       confirm: "确认位置 →",
+      fullscreen: "全屏标点",
+      exitFullscreen: "退出全屏",
       summary: "{label} · {x}% / {y}%",
     },
     step2: {

--- a/src/islands/upload/AnnotateSeatmap.tsx
+++ b/src/islands/upload/AnnotateSeatmap.tsx
@@ -1,42 +1,20 @@
-// Embedded annotation seating chart for the upload Sheet, Step 1 (shape §5
-// "Sheet 内嵌纯净坐席图").
+// Inline annotation seat chart for the upload Sheet, Step 1 (shape §5 "Sheet
+// 内嵌纯净坐席图"). It is the SMALL, framed entry point: a fixed aspect-[3/2]
+// box wrapping the shared <MarkSurface> (the actual zoom/pan + place/drag
+// technique) plus a ⤢ button that hands off to the fullscreen overlay when the
+// little box feels too cramped for precise marking.
 //
-// REUSE WITHOUT INHERITING THE BODY (brief): this shares the *technique* of the
-// main Seatmap island — react-zoom-pan-pinch zoom/pan container + the
-// xPercent/yPercent ↔ surface-pixel conversion + counter-scaling so the marker
-// keeps a constant on-screen size — but it is a SEPARATE, much smaller component
-// because its job is the inverse: place exactly ONE adjustable/undoable point on
-// a PRISTINE chart (no existing annotations, no clustering, no Lightbox handoff,
-// no idle-fading controls). Pulling the main Seatmap in would drag along all the
-// cluster/selected/Lightbox wiring it doesn't need and break the "纯净" intent.
-//
-// Output: a normalized {x,y} in 0..1 (the same space as photos.x_percent /
-// y_percent) handed up via onChange. Click/tap to place; drag the dot to adjust;
-// the Sheet's "撤销 / 重新标" clears it.
+// The marking surface itself (and the normalized {x,y} 0..1 output handed up via
+// onChange) lives in MarkSurface, shared verbatim with FullscreenAnnotate so the
+// two never diverge — both render off the ONE point owned by the Sheet.
 
-import { useCallback, useRef, useState } from "react";
-import {
-  TransformWrapper,
-  TransformComponent,
-  type ReactZoomPanPinchContentRef,
-} from "react-zoom-pan-pinch";
-import { Minus, Plus, RotateCcw } from "lucide-react";
+import { Maximize2 } from "lucide-react";
 import type { Locale } from "@/i18n/config";
 import { useLocale } from "@/hooks/useLocale";
-import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import type { SubMap } from "@/types";
-import { cn } from "@/lib/utils";
+import MarkSurface, { type AnnotationPoint } from "./MarkSurface";
 
-const MIN_SCALE = 1;
-const MAX_SCALE = 6;
-const ZOOM_ANIM_MS = 250;
-
-export interface AnnotationPoint {
-  /** Normalized 0..1, matches photos.x_percent. */
-  x: number;
-  /** Normalized 0..1, matches photos.y_percent. */
-  y: number;
-}
+export type { AnnotationPoint };
 
 interface AnnotateSeatmapProps {
   locale: Locale;
@@ -45,6 +23,8 @@ interface AnnotateSeatmapProps {
   point: AnnotationPoint | null;
   /** Emitted whenever the point is placed or dragged. */
   onChange: (point: AnnotationPoint) => void;
+  /** Open the fullscreen marking overlay (⤢ button). */
+  onRequestFullscreen: () => void;
 }
 
 export default function AnnotateSeatmap({
@@ -52,201 +32,30 @@ export default function AnnotateSeatmap({
   subMap,
   point,
   onChange,
+  onRequestFullscreen,
 }: AnnotateSeatmapProps) {
   const { t } = useLocale(locale);
-  const reducedMotion = usePrefersReducedMotion();
-  const animTime = reducedMotion ? 0 : ZOOM_ANIM_MS;
-
-  const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
-  const surfaceRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(MIN_SCALE);
-  const draggingRef = useRef(false);
-
-  // Convert a client (pointer) position into a normalized 0..1 surface coord,
-  // accounting for the current pan/zoom transform of the content box.
-  const toNormalized = useCallback(
-    (clientX: number, clientY: number): AnnotationPoint | null => {
-      const surface = surfaceRef.current;
-      if (!surface) return null;
-      const rect = surface.getBoundingClientRect();
-      // surfaceRef wraps the (already transformed) content, so its rect IS the
-      // rendered, scaled+panned image box. Normalize within it.
-      const x = (clientX - rect.left) / rect.width;
-      const y = (clientY - rect.top) / rect.height;
-      if (x < 0 || x > 1 || y < 0 || y > 1) return null;
-      return { x: clamp01(x), y: clamp01(y) };
-    },
-    [],
-  );
-
-  // Click/tap to place. Skipped while a drag just happened (the drag handler
-  // owns that gesture) and ignored if it lands outside the image.
-  const handleSurfaceClick = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (draggingRef.current) {
-        draggingRef.current = false;
-        return;
-      }
-      const next = toNormalized(e.clientX, e.clientY);
-      if (next) onChange(next);
-    },
-    [toNormalized, onChange],
-  );
-
-  // Drag the existing dot to adjust. Pointer events on the dot; we stop
-  // propagation so the pan gesture / surface click don't also fire.
-  const handleDotPointerDown = useCallback(
-    (e: React.PointerEvent<HTMLButtonElement>) => {
-      e.stopPropagation();
-      e.preventDefault();
-      const target = e.currentTarget;
-      target.setPointerCapture(e.pointerId);
-      draggingRef.current = true;
-
-      const move = (ev: PointerEvent) => {
-        const next = toNormalized(ev.clientX, ev.clientY);
-        if (next) onChange(next);
-      };
-      const up = (ev: PointerEvent) => {
-        target.releasePointerCapture?.(ev.pointerId);
-        target.removeEventListener("pointermove", move);
-        target.removeEventListener("pointerup", up);
-        // Keep draggingRef true until the click handler clears it (the click
-        // fires right after pointerup on the surface).
-      };
-      target.addEventListener("pointermove", move);
-      target.addEventListener("pointerup", up);
-    },
-    [toNormalized, onChange],
-  );
 
   return (
     <div className="border-border bg-card relative aspect-[3/2] w-full overflow-hidden rounded-md border">
-      <TransformWrapper
-        ref={transformRef}
-        minScale={MIN_SCALE}
-        maxScale={MAX_SCALE}
-        initialScale={MIN_SCALE}
-        centerOnInit
-        limitToBounds
-        doubleClick={{ disabled: true }}
-        wheel={{ step: 0.15 }}
-        panning={{ velocityDisabled: reducedMotion }}
-        onTransformed={(_ref, state) => setScale(state.scale)}
+      <MarkSurface
+        locale={locale}
+        subMap={subMap}
+        point={point}
+        onChange={onChange}
+      />
+
+      {/* ⤢ fullscreen toggle, top-right (clear of the bottom-right zoom stack
+          and the top-left helper line). */}
+      <button
+        type="button"
+        onClick={onRequestFullscreen}
+        aria-label={t.uploadSheet.step1.fullscreen}
+        title={t.uploadSheet.step1.fullscreen}
+        className="bg-card text-foreground border-border hover:bg-secondary focus-visible:ring-ring absolute right-2 top-2 grid size-9 place-items-center rounded-md border transition-colors duration-150 focus-visible:ring-2 focus-visible:outline-none"
       >
-        <TransformComponent
-          wrapperStyle={{ width: "100%", height: "100%", touchAction: "none" }}
-          contentStyle={{ width: "100%", height: "100%" }}
-        >
-          <div
-            ref={surfaceRef}
-            className="relative size-full"
-            onClick={handleSurfaceClick}
-          >
-            <img
-              src={subMap.imageUrl}
-              alt=""
-              draggable={false}
-              className="size-full object-contain select-none"
-            />
-
-            {point && (
-              <button
-                type="button"
-                aria-label={t.uploadSheet.step1.markerLabel}
-                onPointerDown={handleDotPointerDown}
-                className="pointer-events-auto absolute grid size-11 cursor-grab place-items-center rounded-full focus-visible:outline-none active:cursor-grabbing"
-                style={{
-                  left: `${point.x * 100}%`,
-                  top: `${point.y * 100}%`,
-                  // Center on the anchor + counter-scale so the dot stays a
-                  // constant on-screen size as the user zooms (same technique as
-                  // the main seatmap). Centering MUST live only in this inline
-                  // `transform`: Tailwind v4's `-translate-*` utilities emit the
-                  // separate CSS `translate` property, which would STACK on top of
-                  // this and double the offset (dot lands 50% off the click).
-                  transform: `translate(-50%, -50%) scale(${1 / scale})`,
-                  transformOrigin: "center",
-                }}
-              >
-                {/* selected-pin visual: vermilion solid + ink hairline (mirrors
-                    the main seatmap's selected pin — the user is placing exactly
-                    that pin). 朱赤 is allowed here: it is the annotation point. */}
-                <span className="bg-accent border-foreground ring-offset-card group-focus-visible:ring-accent block size-3 scale-110 rounded-full border" />
-              </button>
-            )}
-          </div>
-        </TransformComponent>
-      </TransformWrapper>
-
-      {/* helper line, top-left */}
-      <p className="text-muted-foreground bg-card/80 pointer-events-none absolute left-2 top-2 rounded px-2 py-1 text-xs">
-        {t.uploadSheet.step1.helper}
-      </p>
-
-      {/* compact ⊕ ⊖ ⟲ controls (36px), bottom-right (shape §5) */}
-      <div className="absolute bottom-2 right-2 flex flex-col gap-1">
-        <MiniControl
-          label={t.seatmap.zoomIn}
-          onClick={() =>
-            transformRef.current?.zoomIn(0.4, animTime, "easeOutQuart")
-          }
-          disabled={scale >= MAX_SCALE - 0.01}
-        >
-          <Plus className="size-4" aria-hidden="true" />
-        </MiniControl>
-        <MiniControl
-          label={t.seatmap.zoomOut}
-          onClick={() =>
-            transformRef.current?.zoomOut(0.4, animTime, "easeOutQuart")
-          }
-          disabled={scale <= MIN_SCALE + 0.01}
-        >
-          <Minus className="size-4" aria-hidden="true" />
-        </MiniControl>
-        <MiniControl
-          label={t.seatmap.reset}
-          onClick={() =>
-            transformRef.current?.resetTransform(animTime, "easeOutQuart")
-          }
-          disabled={scale <= MIN_SCALE + 0.01}
-        >
-          <RotateCcw className="size-3.5" aria-hidden="true" />
-        </MiniControl>
-      </div>
+        <Maximize2 className="size-4" aria-hidden="true" />
+      </button>
     </div>
-  );
-}
-
-function clamp01(n: number): number {
-  return Math.min(1, Math.max(0, n));
-}
-
-function MiniControl({
-  label,
-  onClick,
-  disabled,
-  children,
-}: {
-  label: string;
-  onClick: () => void;
-  disabled: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      aria-label={label}
-      className={cn(
-        "bg-card text-foreground border-border grid size-9 place-items-center rounded-md border",
-        "transition-colors duration-150 hover:bg-secondary",
-        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
-        "disabled:cursor-not-allowed disabled:opacity-40",
-      )}
-    >
-      {children}
-    </button>
   );
 }

--- a/src/islands/upload/FullscreenAnnotate.tsx
+++ b/src/islands/upload/FullscreenAnnotate.tsx
@@ -1,0 +1,158 @@
+// Fullscreen marking overlay for Upload Step 1. The inline AnnotateSeatmap box
+// is too small for precise placement (worst on mobile); the ⤢ button opens this
+// near-full-viewport overlay so the seat chart is large and comfortable to mark.
+//
+// Architecture (PRD): this is presentation-only. It renders the SHARED
+// <MarkSurface> off the ONE point the Upload Sheet owns, so placing/dragging
+// here updates the exact same point the inline box shows. Undo + Confirm are
+// handed in from the Sheet — Confirm reuses the Sheet's confirmPoint(), so it
+// closes the overlay AND completes Step 1 (scroll to Step 2) in one tap.
+//
+// Form follows DESIGN.md "用户主动触发的 overlay": a warm-ink scrim (the "focus
+// on this" layer, not a shadow) behind a paper panel. Because the panel is paper
+// (bg-background), the chrome reuses the Sheet's own ink/paper button tokens.
+// Esc priority mirrors the Lightbox detail sheet: we capture Escape here and the
+// Sheet skips its own Esc→close while this is open, so Esc collapses ONLY the
+// overlay and never the whole Sheet.
+
+import { useEffect } from "react";
+import { X } from "lucide-react";
+import type { Locale } from "@/i18n/config";
+import { useLocale } from "@/hooks/useLocale";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import type { SubMap } from "@/types";
+import { cn } from "@/lib/utils";
+import MarkSurface, { type AnnotationPoint } from "./MarkSurface";
+
+const OVERLAY_ANIM_MS = 250;
+
+interface FullscreenAnnotateProps {
+  open: boolean;
+  locale: Locale;
+  subMap: SubMap;
+  /** The single shared point (null = none placed yet). */
+  point: AnnotationPoint | null;
+  /** Place/drag in the overlay updates the shared point. */
+  onChange: (point: AnnotationPoint) => void;
+  /** Clear the point ("撤销"). */
+  onUndo: () => void;
+  /** Confirm = finish Step 1 (the Sheet closes this + advances to Step 2). */
+  onConfirm: () => void;
+  /** Exit without finishing (✕ / Esc / backdrop). */
+  onClose: () => void;
+}
+
+export default function FullscreenAnnotate({
+  open,
+  locale,
+  subMap,
+  point,
+  onChange,
+  onUndo,
+  onConfirm,
+  onClose,
+}: FullscreenAnnotateProps) {
+  const { t } = useLocale(locale);
+  const reducedMotion = usePrefersReducedMotion();
+
+  // Capture Escape ourselves and swallow it, so the Upload Sheet's own
+  // Esc→close handler (which also listens on window, capture) does not also
+  // fire. The Sheet additionally skips its handler while we're open; this
+  // stopImmediatePropagation is the belt to that suspenders.
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopImmediatePropagation();
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[60]"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t.uploadSheet.step1.title}
+    >
+      {/* Warm-ink scrim (a layer of ink, not a shadow). Click the margin to
+          exit. */}
+      <button
+        type="button"
+        aria-hidden="true"
+        tabIndex={-1}
+        onClick={onClose}
+        className="absolute inset-0 cursor-default bg-[oklch(0.15_0.008_75_/_0.92)]"
+        style={
+          reducedMotion
+            ? undefined
+            : { animation: `seatview-overlay-in ${OVERLAY_ANIM_MS}ms ease-out` }
+        }
+      />
+
+      {/* Paper panel, near-full-viewport with a thin ink margin. pointer-events
+          pass through the margin to the scrim; the panel re-enables them. */}
+      <div className="pointer-events-none absolute inset-0 flex p-2 sm:p-3">
+        <div className="border-border bg-background pointer-events-auto relative flex flex-1 flex-col overflow-hidden rounded-lg border">
+          {/* Header: step title + ✕ */}
+          <div className="border-border flex items-center justify-between border-b px-4 py-3">
+            <span className="text-foreground text-sm font-medium">
+              {t.uploadSheet.step1.title}
+            </span>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label={t.uploadSheet.step1.exitFullscreen}
+              className="text-muted-foreground hover:text-foreground focus-visible:ring-ring -mr-1 grid size-9 place-items-center rounded-md focus-visible:ring-2 focus-visible:outline-none"
+            >
+              <X className="size-5" aria-hidden="true" />
+            </button>
+          </div>
+
+          {/* Surface: the large shared marking surface on warm paper. */}
+          <div className="bg-card relative min-h-0 flex-1">
+            <MarkSurface
+              locale={locale}
+              subMap={subMap}
+              point={point}
+              onChange={onChange}
+              large
+            />
+          </div>
+
+          {/* Footer: 撤销 + 确认（确认 = 完成 Step 1）. */}
+          <div className="border-border flex items-center gap-4 border-t px-4 py-3">
+            <button
+              type="button"
+              onClick={onUndo}
+              disabled={!point}
+              className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded-sm text-sm focus-visible:ring-2 focus-visible:outline-none disabled:opacity-40"
+            >
+              {t.uploadSheet.step1.undo}
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              disabled={!point}
+              className={cn(
+                "ml-auto inline-flex h-11 items-center justify-center rounded-md px-6 text-sm font-medium",
+                "bg-accent/10 text-foreground border-accent/30 border",
+                "transition-colors duration-150 hover:bg-accent/15 hover:border-accent/50",
+                "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+              )}
+            >
+              {t.uploadSheet.step1.confirm}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/islands/upload/MarkSurface.tsx
+++ b/src/islands/upload/MarkSurface.tsx
@@ -1,0 +1,260 @@
+// Shared seat-marking surface — the interactive core behind BOTH the inline
+// Step-1 box (AnnotateSeatmap) and the fullscreen overlay (FullscreenAnnotate).
+//
+// It carries ONLY the marking technique: a react-zoom-pan-pinch zoom/pan
+// container + the surface-pixel ↔ normalized {x,y} conversion + counter-scaling
+// so the vermilion dot keeps a constant on-screen size as you zoom, plus the
+// ⊕ ⊖ ⟲ zoom controls and the top-left helper line. It fills its parent (the
+// parent owns framing: the inline box's aspect-[3/2]+border, or the overlay's
+// flex-1 region). Place/drag emits a normalized {x,y} in 0..1 (photos.x_percent
+// space) via onChange; undo/confirm live in the parent so the two surfaces stay
+// in sync off ONE shared point.
+
+import { useCallback, useRef, useState } from "react";
+import {
+  TransformWrapper,
+  TransformComponent,
+  type ReactZoomPanPinchContentRef,
+} from "react-zoom-pan-pinch";
+import { Minus, Plus, RotateCcw } from "lucide-react";
+import type { Locale } from "@/i18n/config";
+import { useLocale } from "@/hooks/useLocale";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import type { SubMap } from "@/types";
+import { cn } from "@/lib/utils";
+
+const MIN_SCALE = 1;
+const MAX_SCALE = 6;
+const ZOOM_ANIM_MS = 250;
+
+export interface AnnotationPoint {
+  /** Normalized 0..1, matches photos.x_percent. */
+  x: number;
+  /** Normalized 0..1, matches photos.y_percent. */
+  y: number;
+}
+
+interface MarkSurfaceProps {
+  locale: Locale;
+  subMap: SubMap;
+  /** Current point (null = none placed yet). */
+  point: AnnotationPoint | null;
+  /** Emitted whenever the point is placed or dragged. */
+  onChange: (point: AnnotationPoint) => void;
+  /** Larger 44px controls for the fullscreen overlay (default: 36px inline). */
+  large?: boolean;
+}
+
+export default function MarkSurface({
+  locale,
+  subMap,
+  point,
+  onChange,
+  large = false,
+}: MarkSurfaceProps) {
+  const { t } = useLocale(locale);
+  const reducedMotion = usePrefersReducedMotion();
+  const animTime = reducedMotion ? 0 : ZOOM_ANIM_MS;
+
+  const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
+  const surfaceRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(MIN_SCALE);
+  const draggingRef = useRef(false);
+
+  // Convert a client (pointer) position into a normalized 0..1 surface coord,
+  // accounting for the current pan/zoom transform of the content box.
+  const toNormalized = useCallback(
+    (clientX: number, clientY: number): AnnotationPoint | null => {
+      const surface = surfaceRef.current;
+      if (!surface) return null;
+      const rect = surface.getBoundingClientRect();
+      // surfaceRef wraps the (already transformed) content, so its rect IS the
+      // rendered, scaled+panned image box. Normalize within it.
+      const x = (clientX - rect.left) / rect.width;
+      const y = (clientY - rect.top) / rect.height;
+      if (x < 0 || x > 1 || y < 0 || y > 1) return null;
+      return { x: clamp01(x), y: clamp01(y) };
+    },
+    [],
+  );
+
+  // Click/tap to place. Skipped while a drag just happened (the drag handler
+  // owns that gesture) and ignored if it lands outside the image.
+  const handleSurfaceClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (draggingRef.current) {
+        draggingRef.current = false;
+        return;
+      }
+      const next = toNormalized(e.clientX, e.clientY);
+      if (next) onChange(next);
+    },
+    [toNormalized, onChange],
+  );
+
+  // Drag the existing dot to adjust. Pointer events on the dot; we stop
+  // propagation so the pan gesture / surface click don't also fire.
+  const handleDotPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      e.preventDefault();
+      const target = e.currentTarget;
+      target.setPointerCapture(e.pointerId);
+      draggingRef.current = true;
+
+      const move = (ev: PointerEvent) => {
+        const next = toNormalized(ev.clientX, ev.clientY);
+        if (next) onChange(next);
+      };
+      const up = (ev: PointerEvent) => {
+        target.releasePointerCapture?.(ev.pointerId);
+        target.removeEventListener("pointermove", move);
+        target.removeEventListener("pointerup", up);
+        // Keep draggingRef true until the click handler clears it (the click
+        // fires right after pointerup on the surface).
+      };
+      target.addEventListener("pointermove", move);
+      target.addEventListener("pointerup", up);
+    },
+    [toNormalized, onChange],
+  );
+
+  return (
+    <div className="relative size-full overflow-hidden">
+      <TransformWrapper
+        ref={transformRef}
+        minScale={MIN_SCALE}
+        maxScale={MAX_SCALE}
+        initialScale={MIN_SCALE}
+        centerOnInit
+        limitToBounds
+        doubleClick={{ disabled: true }}
+        wheel={{ step: 0.15 }}
+        panning={{ velocityDisabled: reducedMotion }}
+        onTransformed={(_ref, state) => setScale(state.scale)}
+      >
+        <TransformComponent
+          wrapperStyle={{ width: "100%", height: "100%", touchAction: "none" }}
+          contentStyle={{ width: "100%", height: "100%" }}
+        >
+          <div
+            ref={surfaceRef}
+            className="relative size-full"
+            onClick={handleSurfaceClick}
+          >
+            <img
+              src={subMap.imageUrl}
+              alt=""
+              draggable={false}
+              className="size-full object-contain select-none"
+            />
+
+            {point && (
+              <button
+                type="button"
+                aria-label={t.uploadSheet.step1.markerLabel}
+                onPointerDown={handleDotPointerDown}
+                className="group pointer-events-auto absolute grid size-11 cursor-grab place-items-center rounded-full focus-visible:outline-none active:cursor-grabbing"
+                style={{
+                  left: `${point.x * 100}%`,
+                  top: `${point.y * 100}%`,
+                  // Center on the anchor + counter-scale so the dot stays a
+                  // constant on-screen size as the user zooms (same technique as
+                  // the main seatmap). Centering MUST live only in this inline
+                  // `transform`: Tailwind v4's `-translate-*` utilities emit the
+                  // separate CSS `translate` property, which would STACK on top
+                  // of this and double the offset (dot lands 50% off the click).
+                  transform: `translate(-50%, -50%) scale(${1 / scale})`,
+                  transformOrigin: "center",
+                }}
+              >
+                {/* selected-pin visual: vermilion solid + ink hairline (mirrors
+                    the main seatmap's selected pin — the user is placing exactly
+                    that pin). 朱赤 is allowed here: it is the annotation point. */}
+                <span className="bg-accent border-foreground ring-offset-card group-focus-visible:ring-accent group-focus-visible:ring-2 group-focus-visible:ring-offset-2 block size-3 scale-110 rounded-full border" />
+              </button>
+            )}
+          </div>
+        </TransformComponent>
+      </TransformWrapper>
+
+      {/* helper line, top-left */}
+      <p className="text-muted-foreground bg-card/80 pointer-events-none absolute left-2 top-2 rounded px-2 py-1 text-xs">
+        {t.uploadSheet.step1.helper}
+      </p>
+
+      {/* compact ⊕ ⊖ ⟲ controls, bottom-right (shape §5) */}
+      <div className="absolute bottom-2 right-2 flex flex-col gap-1">
+        <MiniControl
+          label={t.seatmap.zoomIn}
+          large={large}
+          onClick={() =>
+            transformRef.current?.zoomIn(0.4, animTime, "easeOutQuart")
+          }
+          disabled={scale >= MAX_SCALE - 0.01}
+        >
+          <Plus className={large ? "size-5" : "size-4"} aria-hidden="true" />
+        </MiniControl>
+        <MiniControl
+          label={t.seatmap.zoomOut}
+          large={large}
+          onClick={() =>
+            transformRef.current?.zoomOut(0.4, animTime, "easeOutQuart")
+          }
+          disabled={scale <= MIN_SCALE + 0.01}
+        >
+          <Minus className={large ? "size-5" : "size-4"} aria-hidden="true" />
+        </MiniControl>
+        <MiniControl
+          label={t.seatmap.reset}
+          large={large}
+          onClick={() =>
+            transformRef.current?.resetTransform(animTime, "easeOutQuart")
+          }
+          disabled={scale <= MIN_SCALE + 0.01}
+        >
+          <RotateCcw
+            className={large ? "size-4" : "size-3.5"}
+            aria-hidden="true"
+          />
+        </MiniControl>
+      </div>
+    </div>
+  );
+}
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+function MiniControl({
+  label,
+  onClick,
+  disabled,
+  large,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled: boolean;
+  large: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      className={cn(
+        "bg-card text-foreground border-border grid place-items-center rounded-md border",
+        large ? "size-11" : "size-9",
+        "transition-colors duration-150 hover:bg-secondary",
+        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+        "disabled:cursor-not-allowed disabled:opacity-40",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/islands/upload/UploadSheet.tsx
+++ b/src/islands/upload/UploadSheet.tsx
@@ -33,6 +33,7 @@ import { signUpload, commitUpload, UploadError } from "@/lib/upload-client";
 import { DESCRIPTION_MAX, SEAT_LABEL_MAX } from "@/lib/upload";
 import { cn } from "@/lib/utils";
 import AnnotateSeatmap, { type AnnotationPoint } from "./AnnotateSeatmap";
+import FullscreenAnnotate from "./FullscreenAnnotate";
 import DateField from "./DateField";
 import TurnstileWidget from "./TurnstileWidget";
 import SuccessBookmark from "./SuccessBookmark";
@@ -75,6 +76,8 @@ export default function UploadSheet({
   // ── Step data ─────────────────────────────────────────────────────────────
   const [point, setPoint] = useState<AnnotationPoint | null>(null);
   const [pointConfirmed, setPointConfirmed] = useState(false);
+  // Fullscreen marking overlay (Step 1). Shares `point` with the inline box.
+  const [fullscreenOpen, setFullscreenOpen] = useState(false);
 
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imageBytes, setImageBytes] = useState<number>(0);
@@ -180,9 +183,13 @@ export default function UploadSheet({
   }, [succeeded, anyProgress, onClose]);
 
   // Esc → same close logic. Focus trap is provided by the sheet container.
+  // While the fullscreen marking overlay is open, it owns Escape (collapses
+  // itself first), so the Sheet skips its own close handler — same priority
+  // technique as the Lightbox detail sheet.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
+        if (fullscreenOpen) return;
         e.stopPropagation();
         e.preventDefault();
         requestClose();
@@ -190,7 +197,7 @@ export default function UploadSheet({
     }
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);
-  }, [requestClose]);
+  }, [requestClose, fullscreenOpen]);
 
   // ── Step 1: annotate ────────────────────────────────────────────────────────
   const confirmPoint = useCallback(() => {
@@ -474,6 +481,7 @@ export default function UploadSheet({
                     subMap={subMap}
                     point={point}
                     onChange={setPoint}
+                    onRequestFullscreen={() => setFullscreenOpen(true)}
                   />
                   <div className="flex items-center gap-4 text-sm">
                     <button
@@ -701,6 +709,23 @@ export default function UploadSheet({
           </>
         )}
       </div>
+
+      {/* Fullscreen marking overlay (Step 1). Paints above the panel (z-[60]);
+          shares `point` so place/drag here syncs the inline box. Confirm reuses
+          confirmPoint() → closes overlay + completes Step 1 + scrolls to Step 2. */}
+      <FullscreenAnnotate
+        open={fullscreenOpen}
+        locale={locale}
+        subMap={subMap}
+        point={point}
+        onChange={setPoint}
+        onUndo={undoPoint}
+        onConfirm={() => {
+          confirmPoint();
+          setFullscreenOpen(false);
+        }}
+        onClose={() => setFullscreenOpen(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 背景

issue #9：上传自己视角图时，桌面端在右侧侧栏、移动端在上滑栏中的小窗里标点，可编辑区域太小，体验不佳。

## 改动

- 抽出共享 **`MarkSurface`**（缩放/平移 + 点击标点 + 反缩放朱赤点 + ⊕⊖⟲ 控件 + helper），内嵌 `AnnotateSeatmap` 与新建 `FullscreenAnnotate` 复用同一份，标点 state 由 Sheet 单一持有、两边同步。
- 内嵌 `AnnotateSeatmap` 右上角新增 **⤢ 全屏按钮**（桌面 / 移动端一致，opt-in）。
- 新建 **`FullscreenAnnotate`**：墨色 scrim + 近全屏纸面 panel，header（步骤标题 + ✕）/ 大号 `MarkSurface` / footer（撤销 + 确认位置）。
  - **Esc / ✕ 仅关闭全屏**（不关 Sheet、不丢进度）；与 Sheet 的 Esc 捕获用双保险（Sheet `if (fullscreenOpen) return` + overlay `stopImmediatePropagation`）。
  - **确认复用 `confirmPoint()`** → 关全屏 + 完成 Step 1 + 自动滚到 Step 2。
- 补 `zh/ja/en/ko` 的 `step1.fullscreen` / `step1.exitFullscreen` 文案。
- 标注点补齐键盘 focus ring（与主 Seatmap pin 一致）。

DESIGN.md 约束遵守：墨 overlay（非 box-shadow）、朱赤实心核 + 纸色 halo、Flat Folio。

## 测试

- [x] `astro check` 0 error / 0 warning，prettier、`astro build` 全绿
- [x] 浏览器实测桌面 1280×860 + 移动 390×844：⤢ 打开、标点同步内嵌、Esc 仅关全屏、确认推进 Step 2
- [x] 移动端全屏坐席图填满全宽（相对原小窗显著改善）

Closes #9