### PR TITLE
fix: 已收录的暂存场馆禁用附议（隐藏「我也想看」+ 提示区同步）(issue #15)

### DIFF
--- a/src/islands/StagingForm.tsx
+++ b/src/islands/StagingForm.tsx
@@ -127,9 +127,19 @@ export default function StagingForm({
   const matchCorpus = useMemo<StagingNameDto[]>(() => {
     const byId = new Map<string, StagingNameDto>();
     for (const n of namesCorpus)
-      byId.set(n.id, { id: n.id, name: n.name, voteCount: n.voteCount });
+      byId.set(n.id, {
+        id: n.id,
+        name: n.name,
+        voteCount: n.voteCount,
+        processed: n.processed,
+      });
     for (const v of venues)
-      byId.set(v.id, { id: v.id, name: v.name, voteCount: v.voteCount });
+      byId.set(v.id, {
+        id: v.id,
+        name: v.name,
+        voteCount: v.voteCount,
+        processed: v.processed,
+      });
     return [...byId.values()];
   }, [namesCorpus, venues]);
   const stagingFuse = useMemo(
@@ -178,10 +188,17 @@ export default function StagingForm({
   const stagedView = (item: StagingNameDto) => {
     const inList = venues.find((v) => v.id === item.id);
     if (inList)
-      return { voteCount: inList.voteCount, votedByMe: inList.votedByMe };
-    return (
-      voteOverlay[item.id] ?? { voteCount: item.voteCount, votedByMe: false }
-    );
+      return {
+        voteCount: inList.voteCount,
+        votedByMe: inList.votedByMe,
+        processed: inList.processed,
+      };
+    const overlay = voteOverlay[item.id];
+    return {
+      voteCount: overlay?.voteCount ?? item.voteCount,
+      votedByMe: overlay?.votedByMe ?? false,
+      processed: item.processed,
+    };
   };
 
   const showMatches =
@@ -501,7 +518,13 @@ export default function StagingForm({
                           <span className="text-muted-foreground text-xs [font-variant-numeric:tabular-nums]">
                             {votesText}
                           </span>
-                          {view.votedByMe ? (
+                          {view.processed ? (
+                            // 已收录 → no +1 affordance (issue #15). Sumi ✓ marker.
+                            <span className="text-foreground inline-flex items-center gap-1 text-xs">
+                              <span aria-hidden="true">✓</span>
+                              {t.staging.processed}
+                            </span>
+                          ) : view.votedByMe ? (
                             <span className="text-foreground inline-flex items-center gap-1 text-xs">
                               <span aria-hidden="true">✓</span>
                               {t.staging.plusOneDone}
@@ -750,27 +773,31 @@ function StagingRow({
               {processedLabel}
             </span>
           )}
-          {venue.votedByMe ? (
-            <span className="text-foreground inline-flex items-center gap-1 text-xs">
-              <span aria-hidden="true">✓</span>
-              {plusOneDoneLabel}
-            </span>
-          ) : (
-            <button
-              type="button"
-              onClick={() => onPlusOne(venue.id)}
-              disabled={plusOneBlocked}
-              aria-label={plusOneAriaLabel.replace("{name}", venue.name)}
-              className={cn(
-                "border-border text-muted-foreground inline-flex h-8 shrink-0 items-center rounded-md border px-3 text-xs font-medium",
-                "transition-colors duration-150 hover:text-foreground hover:border-foreground/40",
-                "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
-                "disabled:cursor-not-allowed disabled:opacity-50",
-              )}
-            >
-              {plusOneLabel}
-            </button>
-          )}
+          {/* 已收录 → no +1 affordance at all (issue #15); the ✓ 已收录 marker
+              above already states the terminal state. Only un-collected rows
+              carry the +1 / ✓ 已附议 control. */}
+          {!venue.processed &&
+            (venue.votedByMe ? (
+              <span className="text-foreground inline-flex items-center gap-1 text-xs">
+                <span aria-hidden="true">✓</span>
+                {plusOneDoneLabel}
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => onPlusOne(venue.id)}
+                disabled={plusOneBlocked}
+                aria-label={plusOneAriaLabel.replace("{name}", venue.name)}
+                className={cn(
+                  "border-border text-muted-foreground inline-flex h-8 shrink-0 items-center rounded-md border px-3 text-xs font-medium",
+                  "transition-colors duration-150 hover:text-foreground hover:border-foreground/40",
+                  "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+                  "disabled:cursor-not-allowed disabled:opacity-50",
+                )}
+              >
+                {plusOneLabel}
+              </button>
+            ))}
         </div>
       </div>
     </li>

--- a/src/lib/staging-client.ts
+++ b/src/lib/staging-client.ts
@@ -91,8 +91,9 @@ export async function plusOneStaging(
 }
 
 /**
- * Fetch the public, edge-cached dedup-match corpus ({id,name,voteCount},
- * most-seconded-first, capped — issue #3). Resolves with [] on ANY failure: the
+ * Fetch the public, edge-cached dedup-match corpus ({id,name,voteCount,
+ * processed}, most-seconded-first, capped — issue #3). Resolves with [] on ANY
+ * failure: the
  * staging form's "may already exist" hint is a soft enhancement, never blocking,
  * so a missing corpus simply means no staged-side matches are shown.
  */

--- a/src/lib/staging.ts
+++ b/src/lib/staging.ts
@@ -46,13 +46,17 @@ export interface StagingListResponse {
 
 /**
  * Lightweight staging row for the dedup-match corpus (issue #3). Carries ONLY
- * the public, viewer-independent columns — no `votedByMe`, no `ip_hash`, no
- * `processed` — so GET /api/staging/names can be cached publicly at the edge.
+ * public, viewer-independent columns — no `votedByMe`, no `ip_hash` — so GET
+ * /api/staging/names can be cached publicly at the edge. `processed` is itself
+ * viewer-independent and public, so it rides along (issue #15): the form hides
+ * the +1 on an already-collected suggestion surfaced in the dedup hint.
  */
 export interface StagingNameDto {
   id: string;
   name: string;
   voteCount: number;
+  /** Maintainer marked it 已收录 (`processed_at != null`) → +1 hidden (issue #15). */
+  processed: boolean;
 }
 
 /** GET /api/staging/names body: the capped, public-cacheable match corpus. */

--- a/src/server/staging.ts
+++ b/src/server/staging.ts
@@ -11,6 +11,7 @@
 
 import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
 import type { Db } from "@/server/db";
+import type { StagingNameDto } from "@/lib/staging";
 import { newId } from "@/server/id";
 import {
   stagingVenues,
@@ -97,24 +98,33 @@ export async function listStagingVenues(
 
 /**
  * Lightweight list for the staging-area dedup-match corpus (issue #3). Returns
- * ONLY the public {id, name, voteCount}, most-seconded first, capped at `limit`.
- * Deliberately has NO per-viewer `votedByMe` query (so GET /api/staging/names is
- * public-cacheable at the edge) and NO `ip_hash`. Backs the staging form's
+ * ONLY the public {id, name, voteCount, processed}, most-seconded first, capped
+ * at `limit`. Deliberately has NO per-viewer `votedByMe` query (so GET
+ * /api/staging/names is public-cacheable at the edge) and NO `ip_hash`;
+ * `processed` is viewer-independent so it stays public (issue #15 — the form
+ * hides the +1 on an already-collected hint match). Backs the staging form's
  * "this venue may already exist / already be requested" hint.
  */
 export async function listStagingNames(
   db: Db,
   limit: number,
-): Promise<{ id: string; name: string; voteCount: number }[]> {
-  return db
+): Promise<StagingNameDto[]> {
+  const rows = await db
     .select({
       id: stagingVenues.id,
       name: stagingVenues.name,
       voteCount: stagingVenues.voteCount,
+      processedAt: stagingVenues.processedAt,
     })
     .from(stagingVenues)
     .orderBy(desc(stagingVenues.voteCount), desc(stagingVenues.createdAt))
     .limit(limit);
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    voteCount: row.voteCount,
+    processed: row.processedAt != null,
+  }));
 }
 
 /**


### PR DESCRIPTION
## 背景

issue #15：暂存区（心愿名录）里已被维护者标记「已收录」(`processed`) 的场馆，此前仍显示可点击的「我也想看」附议按钮。附议在 PRODUCT.md 中定义为"给维护者的需求强度信号——决定优先把哪个场馆转正式"，对一个已收录/已转正的场馆继续附议在逻辑上无意义。

## 方案

issue 提了两个方向（加跳转链接 / 禁用附议）。`staging_venues` 仅有 `processed_at` 布尔标记、无指向正式 venue 的外键，"跳转链接"无可靠目标 id（需新增 schema + 后台录入 + 数据回填）。故选**禁用附议**：已收录行直接隐藏按钮（契合 PRODUCT.md 克制呈现），不做灰态占位。

## 改动

- **`StagingRow`**：`processed` 行不再渲染附议按钮，仅保留「✓ 已收录」标记。
- **dedup-hint（搜索提示区）同步**：给 `StagingNameDto` / `listStagingNames` 补 public 的 `processed` 字段（viewer-independent，不破坏 `/api/staging/names` 边缘公开缓存），提示区的已收录项也隐藏附议。
- 未收录场馆附议行为不变；**无 schema 迁移、无后端 +1 逻辑改动**。

## 验证

- `npm run typecheck`（astro check）0 错误 / `prettier` clean / `npm run build` 通过
- 本地 dev server + D1 实地验证：插入一条已收录、一条未收录暂存行
  - 暂存区列表：已收录仅「✓ 已收录」无按钮；未收录有「我也想看」按钮
  - 输入关键词触发提示区：同上，已收录隐藏附议、未收录保留
  - 控制台 0 错误

Closes #15