### PR TITLE
fix: 场馆暂存搜索去重——同一场馆同时命中两区时只保留已收录提示 (issue #14)

### DIFF
--- a/src/islands/StagingForm.tsx
+++ b/src/islands/StagingForm.tsx
@@ -158,20 +158,21 @@ export default function StagingForm({
     const query: Expression = {
       $and: matchQuery.split(/\s+/).map((tok) => ({ name: `'${tok}` })),
     };
-    const matched = stagingFuse
-      .search(query)
-      .slice(0, MATCH_RESULTS)
-      .map((r) => r.item);
     // issue #14: a venue that is BOTH collected and still has a staging request
     // must surface ONLY the 已收录 hint, never twice. Drop any staged match whose
     // name resolves (via the shared venueFuse) to a collected venue already shown
     // in venueMatches — there is no id link between the two, so dedup by name.
-    if (venueMatches.length === 0) return matched;
+    // Filter before capping, so duplicates in the top ranks do not hide later
+    // valid staged matches.
+    const matched = stagingFuse.search(query).map((r) => r.item);
+    if (venueMatches.length === 0) return matched.slice(0, MATCH_RESULTS);
     const collectedIds = new Set(venueMatches.map((v) => v.id));
-    return matched.filter((m) => {
-      const hit = venueFuse.search(venueExtendedQuery(m.name))[0]?.item;
-      return !(hit && collectedIds.has(hit.id));
-    });
+    return matched
+      .filter((m) => {
+        const hit = venueFuse.search(venueExtendedQuery(m.name))[0]?.item;
+        return !(hit && collectedIds.has(hit.id));
+      })
+      .slice(0, MATCH_RESULTS);
   }, [stagingFuse, matchQuery, venueMatches, venueFuse]);
 
   // Fetch the match corpus once, lazily, on the FIRST keystroke — and ONLY when

--- a/src/islands/StagingForm.tsx
+++ b/src/islands/StagingForm.tsx
@@ -158,11 +158,21 @@ export default function StagingForm({
     const query: Expression = {
       $and: matchQuery.split(/\s+/).map((tok) => ({ name: `'${tok}` })),
     };
-    return stagingFuse
+    const matched = stagingFuse
       .search(query)
       .slice(0, MATCH_RESULTS)
       .map((r) => r.item);
-  }, [stagingFuse, matchQuery]);
+    // issue #14: a venue that is BOTH collected and still has a staging request
+    // must surface ONLY the 已收录 hint, never twice. Drop any staged match whose
+    // name resolves (via the shared venueFuse) to a collected venue already shown
+    // in venueMatches — there is no id link between the two, so dedup by name.
+    if (venueMatches.length === 0) return matched;
+    const collectedIds = new Set(venueMatches.map((v) => v.id));
+    return matched.filter((m) => {
+      const hit = venueFuse.search(venueExtendedQuery(m.name))[0]?.item;
+      return !(hit && collectedIds.has(hit.id));
+    });
+  }, [stagingFuse, matchQuery, venueMatches, venueFuse]);
 
   // Fetch the match corpus once, lazily, on the FIRST keystroke — and ONLY when
   // the table is bigger than the SSR batch (otherwise the loaded list already is


### PR DESCRIPTION
## Summary
- 修复 #14：场馆暂存搜索的相似提示中，当同一场馆既在「已收录区」又在「暂存区」时，会重复弹出两个候选。
- 在 `StagingForm.tsx` 的 `stagedMatches` 派生逻辑里加入按名称去重：暂存候选用现有 `venueFuse`（`venueExtendedQuery`）二次解析，若命中的已收录场馆正好出现在当前展示的「已收录区」候选里，则丢弃该暂存候选，仅保留「这些场馆可能已经收录了」提示。
- 暂存项与已收录 venue 之间无 id 关联，故只能按名称去重（复用既有 Fuse 配置，符合 code-reuse 约定）。

## Behavior
| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| 仅暂存命中 | 1 候选 | 1 候选（不变） |
| 仅已收录命中 | 1 候选 | 1 候选（不变） |
| 两区都命中（同一场馆） | 2 候选 | 仅「已收录」提示 |
| 相似但不同的场馆 | — | 不被误抑制 |

## Test plan
- [x] `astro check` typecheck：0 errors
- [x] prettier：clean
- [x] 用真实 18 个场馆数据 + 模拟暂存语料跑匹配管线，4 个场景全部符合预期（日本武道館/武道館 抑制、中野サンプラザ 保留、横浜スタジアム 不误抑制）
- [ ] 浏览器手测：需向本地 D1 塞一条与已收录场馆同名的暂存记录后复现（项目无单测框架）