### PR TITLE
fix: 上传 Sheet 打开时不再自动聚焦座位号输入框 (issue #17)

### DIFF
--- a/src/islands/upload/UploadSheet.tsx
+++ b/src/islands/upload/UploadSheet.tsx
@@ -556,6 +556,7 @@ export default function UploadSheet({
                 <Step3Body
                   t={t}
                   locale={locale}
+                  isActive={activeStep === 3}
                   seatLabel={seatLabel}
                   setSeatLabel={(v) => {
                     setSeatLabel(v);
@@ -924,6 +925,7 @@ function Step2Body({
 function Step3Body({
   t,
   locale,
+  isActive,
   seatLabel,
   setSeatLabel,
   seatError,
@@ -937,6 +939,11 @@ function Step3Body({
 }: {
   t: ReturnType<typeof useLocale>["t"];
   locale: Locale;
+  /** Step 3 is the current step. The seat input focuses only once the user
+   *  REACHES step 3 — not on mount (this body is always rendered in the
+   *  accumulative single page), which would steal focus / pop the mobile
+   *  keyboard the instant the Sheet opens (issue #17). */
+  isActive: boolean;
   seatLabel: string;
   setSeatLabel: (v: string) => void;
   seatError: boolean;
@@ -950,8 +957,8 @@ function Step3Body({
 }) {
   const seatRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
-    seatRef.current?.focus();
-  }, []);
+    if (isActive) seatRef.current?.focus();
+  }, [isActive]);
 
   return (
     <div className="space-y-4 pt-1">


### PR DESCRIPTION
## 背景

手机端点击「上传我的视角」打开 UploadSheet 时，座位号输入框被自动聚焦，立即拉起软键盘，体验差（issue #17）。

## 根因

UploadSheet 是「累积式单页」——只有 `done` 步骤折叠，`todo`/`current` 步骤的内容也会渲染。`Step3Body` 用 `useEffect(() => seatRef.current?.focus(), [])` 在挂载时聚焦座位号输入框，而它在 Sheet 一打开就挂载，于是「打开瞬间」就抢焦点（手机拉键盘；桌面端则把焦点从 Step 1 抢走）。

这也偏离了 `shape-upload-sheet.md` 的本意：首屏应聚焦 Step 1 坐席图，座位号 input 的自动聚焦应在用户**走到 Step 3** 时发生。

## 改动

`src/islands/upload/UploadSheet.tsx`：给 `Step3Body` 传入 `isActive={activeStep === 3}`，把聚焦从「挂载即触发」改为「仅在 Step 3 active 时触发」：

```ts
useEffect(() => {
  if (isActive) seatRef.current?.focus();
}, [isActive]);
```

既修复 bug，又保留规范的「座位号 input 自动 focus」+「首屏聚焦 Step 1」。

## 验证

- `astro check`：0 errors；prettier 格式通过。
- 浏览器（390×844 移动视口，k-arena-yokohama）：
  - 打开 Sheet → 座位号输入框未聚焦、焦点停在上传按钮（不拉键盘）✓
  - 选图后到达 Step 3 → 座位号输入框自动聚焦 ✓

Closes #17