### PR TITLE
fix: 全屏标点统一为 3:2 框，修复落图坐标偏移 (issue #16)

### DIFF
--- a/src/islands/upload/FullscreenAnnotate.tsx
+++ b/src/islands/upload/FullscreenAnnotate.tsx
@@ -115,15 +115,32 @@ export default function FullscreenAnnotate({
             </button>
           </div>
 
-          {/* Surface: the large shared marking surface on warm paper. */}
-          <div className="bg-card relative min-h-0 flex-1">
-            <MarkSurface
-              locale={locale}
-              subMap={subMap}
-              point={point}
-              onChange={onChange}
-              large
-            />
+          {/* Surface: the large shared marking surface on warm paper. The inner
+              box MUST keep the SAME 3:2 frame as the inline AnnotateSeatmap box
+              and the main Seatmap (SeatmapFrame): x_percent/y_percent are
+              normalized within a 3:2 render box, so letting the surface fill a
+              non-3:2 flex-1 region skewed MarkSurface.toNormalized — fullscreen
+              marks looked right on screen but landed offset on the chart (issue
+              #16). We contain a 3:2 box in the available space via container-
+              query units: width = min(container width, 1.5×container height), so
+              it maxes out without overflowing either axis (warm-paper letterbox
+              fills the rest). */}
+          <div
+            className="bg-card relative flex min-h-0 flex-1 items-center justify-center p-2"
+            style={{ containerType: "size" }}
+          >
+            <div
+              className="relative aspect-[3/2]"
+              style={{ width: "min(100cqw, 150cqh)" }}
+            >
+              <MarkSurface
+                locale={locale}
+                subMap={subMap}
+                point={point}
+                onChange={onChange}
+                large
+              />
+            </div>
           </div>
 
           {/* Footer: 撤销 + 确认（确认 = 完成 Step 1）. */}


### PR DESCRIPTION
## Summary

修复 issue #16：上传座位图标点时，**全屏放大模式下标点在全屏里看着正确，但落到底图（及返回内嵌框）后坐标偏移**。

**根因**：`x_percent`/`y_percent` 的坐标契约是「相对 3:2 渲染框归一化」——主图 `SeatmapFrame` 与内嵌 `AnnotateSeatmap` 都是 `aspect-[3/2]`，底图在框内 `object-contain`（底图实际比例各异，框内必有 letterbox 留白）。全屏 `FullscreenAnnotate` 此前让共享的 `MarkSurface` 撑满非 3:2 的 `flex-1` 区域，使 `toNormalized` 相对一个不同比例的框做归一化 → 与 3:2 契约不一致。全屏里「看着对」是因为标点显示与点击用同一个 flex-1 坐标系，一落到 3:2 契约（底图 / 内嵌框）就暴露偏差。

**修复**：在全屏 surface 区内用一个 3:2 比例、按 `width: min(100cqw, 150cqh)` 在可用空间内 contain 居中的盒子包裹 `MarkSurface`，让全屏标记面与内嵌框 / 主图共用同一 3:2 坐标系。

- 只改 `src/islands/upload/FullscreenAnnotate.tsx` 的布局
- 不改 `MarkSurface` 坐标逻辑、不改 `x_percent` 语义、不动已存数据
- 代价：全屏图片按 3:2 居中，宽屏左右 / 竖屏上下会有 warm-paper 留白

## Test plan

- [x] `astro check`：0 errors / 0 warnings；prettier 通过
- [x] 浏览器实测（Chrome，k-arena 2048×939 宽图）：全屏 surface 宽高比 = 1.500（精确 3:2）、内嵌 = 1.503
- [x] 全屏点击 65% 位置 → point = 64.90%（`toNormalized` 相对 3:2 框正确）
- [x] 全屏标点后关闭 → 内嵌框点位 = 64.90%，完全一致（issue 评论的「返回侧栏位置不同」症状消除）
- [ ] 移动端竖屏真机复测留白观感