### PR TITLE
refactor: 标点坐标改为相对图片真实矩形，全屏不再受 3:2 框限制 (issue #16)

### DIFF
--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState, type RefObject } from "react";
+
+// Track an element's rendered (CSS) size as a React value, kept fresh by a
+// ResizeObserver. Used by the seatmap + the upload mark surface to know the
+// UNSCALED container box so they can compute the object-contain content rect
+// (src/lib/image-rect.ts) — the annotation coordinate base. The observed box is
+// the static frame (NOT the zoom/pan-transformed layer), so the size only
+// changes on layout/resize (viewport, fullscreen open), not on every zoom tick.
+
+export interface ElementSize {
+  width: number;
+  height: number;
+}
+
+const ZERO: ElementSize = { width: 0, height: 0 };
+
+/**
+ * Observe `ref`'s border-box size. Returns `{0,0}` until the element mounts and
+ * the first observation fires (callers fall back to the full container, so a
+ * single pre-measure frame renders harmlessly).
+ */
+export function useElementSize(
+  ref: RefObject<HTMLElement | null>,
+): ElementSize {
+  const [size, setSize] = useState<ElementSize>(ZERO);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const rect = entry.contentRect;
+      setSize({ width: rect.width, height: rect.height });
+    });
+    observer.observe(el);
+    // Seed synchronously so the first paint has real dimensions where possible.
+    const rect = el.getBoundingClientRect();
+    setSize({ width: rect.width, height: rect.height });
+
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return size;
+}

--- a/src/islands/Seatmap.tsx
+++ b/src/islands/Seatmap.tsx
@@ -10,8 +10,10 @@ import { getMessages, subMapLabel } from "@/i18n";
 import { fillTemplate } from "@/lib/format";
 import { useLocale } from "@/hooks/useLocale";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { useElementSize } from "@/hooks/useElementSize";
 import { setSelectedPhoto } from "@/lib/selected-photo";
 import { clusterPoints, layOutPoints, type Cluster } from "@/lib/cluster";
+import { imageContentRect } from "@/lib/image-rect";
 import type { PhotoDto } from "@/lib/photos";
 import type { SubMap } from "@/types";
 import { cn } from "@/lib/utils";
@@ -75,6 +77,9 @@ export default function Seatmap({
 
   const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  // Unscaled frame box (NOT the zoom/pan-transformed layer) → the object-contain
+  // chart-image content rect that pins anchor to. Re-measured on resize.
+  const wrapperSize = useElementSize(wrapperRef);
 
   // Live transform state, driven by onTransformed. Drives clustering threshold,
   // counter-scaling, and the scale indicator.
@@ -134,12 +139,17 @@ export default function Seatmap({
 
       const targetScale = Math.min(scale * CLUSTER_ZOOM_FACTOR, MAX_SCALE);
       const rect = wrapper.getBoundingClientRect();
-      // Surface coordinate of the centroid relative to the rendered image. The
-      // image is object-contain inside the wrapper; clusters are positioned in
-      // image-surface px (width/height), and the TransformComponent content box
-      // matches the wrapper size, so normalize centroid to the wrapper extent.
-      const surfaceX = (cluster.x / subMap.width) * rect.width;
-      const surfaceY = (cluster.y / subMap.height) * rect.height;
+      // The chart is object-contain inside the wrapper, so clusters (in image
+      // pixels) map to the IMAGE CONTENT rect, not the whole wrapper — the
+      // letterbox offset must be added or the centroid lands in the slack.
+      const cr = imageContentRect(
+        rect.width,
+        rect.height,
+        subMap.width,
+        subMap.height,
+      );
+      const surfaceX = cr.offsetX + (cluster.x / subMap.width) * cr.width;
+      const surfaceY = cr.offsetY + (cluster.y / subMap.height) * cr.height;
       const positionX = rect.width / 2 - surfaceX * targetScale;
       const positionY = rect.height / 2 - surfaceY * targetScale;
 
@@ -226,10 +236,13 @@ export default function Seatmap({
             <div className="relative size-full" onPointerDown={wakeControls}>
               <ChartImage subMap={subMap} locale={locale} />
 
-              {/* Annotation overlay: pins + cluster bubbles. */}
+              {/* Annotation overlay: pins + cluster bubbles. Positioned against
+                  the object-contain image content rect (image-relative coords),
+                  not the raw frame, so pins land on real chart pixels on any
+                  aspect ratio. */}
               {clusters.map((cluster) => {
-                const leftPct = (cluster.x / subMap.width) * 100;
-                const topPct = (cluster.y / subMap.height) * 100;
+                const leftPct = clusterPctX(cluster, subMap, wrapperSize);
+                const topPct = clusterPctY(cluster, subMap, wrapperSize);
                 const isCluster = cluster.members.length > 1;
                 return (
                   <div
@@ -316,6 +329,47 @@ export default function Seatmap({
         }}
       />
     </SeatmapFrame>
+  );
+}
+
+/* ── Overlay positioning helpers ───────────────────────────────────────────
+ * A cluster lives at image pixel (cluster.x, cluster.y). The overlay layer fills
+ * the UNSCALED frame (wrapperSize), but the chart is object-contain within it, so
+ * a pin's percent position is (contentOffset + imageFraction·contentSize) over
+ * the frame extent. Before the frame is measured we fall back to the raw image
+ * fraction (correct for a 3:2 frame on a 3:2 chart, harmless for one frame). */
+function clusterPctX(
+  cluster: Cluster,
+  subMap: SubMap,
+  frame: { width: number; height: number },
+): number {
+  if (frame.width <= 0) return (cluster.x / subMap.width) * 100;
+  const cr = imageContentRect(
+    frame.width,
+    frame.height,
+    subMap.width,
+    subMap.height,
+  );
+  return (
+    ((cr.offsetX + (cluster.x / subMap.width) * cr.width) / frame.width) * 100
+  );
+}
+
+function clusterPctY(
+  cluster: Cluster,
+  subMap: SubMap,
+  frame: { width: number; height: number },
+): number {
+  if (frame.height <= 0) return (cluster.y / subMap.height) * 100;
+  const cr = imageContentRect(
+    frame.width,
+    frame.height,
+    subMap.width,
+    subMap.height,
+  );
+  return (
+    ((cr.offsetY + (cluster.y / subMap.height) * cr.height) / frame.height) *
+    100
   );
 }
 

--- a/src/islands/upload/FullscreenAnnotate.tsx
+++ b/src/islands/upload/FullscreenAnnotate.tsx
@@ -115,32 +115,22 @@ export default function FullscreenAnnotate({
             </button>
           </div>
 
-          {/* Surface: the large shared marking surface on warm paper. The inner
-              box MUST keep the SAME 3:2 frame as the inline AnnotateSeatmap box
-              and the main Seatmap (SeatmapFrame): x_percent/y_percent are
-              normalized within a 3:2 render box, so letting the surface fill a
-              non-3:2 flex-1 region skewed MarkSurface.toNormalized — fullscreen
-              marks looked right on screen but landed offset on the chart (issue
-              #16). We contain a 3:2 box in the available space via container-
-              query units: width = min(container width, 1.5×container height), so
-              it maxes out without overflowing either axis (warm-paper letterbox
-              fills the rest). */}
-          <div
-            className="bg-card relative flex min-h-0 flex-1 items-center justify-center p-2"
-            style={{ containerType: "size" }}
-          >
-            <div
-              className="relative aspect-[3/2]"
-              style={{ width: "min(100cqw, 150cqh)" }}
-            >
-              <MarkSurface
-                locale={locale}
-                subMap={subMap}
-                point={point}
-                onChange={onChange}
-                large
-              />
-            </div>
+          {/* Surface: the large shared marking surface fills the whole flex-1
+              region (TRUE fullscreen). x_percent/y_percent are now normalized
+              against the chart's real object-contain content rect (not a render
+              frame), so MarkSurface stays correct in any aspect ratio — no need
+              to box it into a 3:2 frame. This removes the issue #16 workaround:
+              the chart object-contains within the region, letterbox slack is
+              excluded from the coordinate base, and screen real estate is no
+              longer wasted on a forced 3:2 letterbox. */}
+          <div className="bg-card relative flex min-h-0 flex-1 p-2">
+            <MarkSurface
+              locale={locale}
+              subMap={subMap}
+              point={point}
+              onChange={onChange}
+              large
+            />
           </div>
 
           {/* Footer: 撤销 + 确认（确认 = 完成 Step 1）. */}

--- a/src/islands/upload/MarkSurface.tsx
+++ b/src/islands/upload/MarkSurface.tsx
@@ -2,13 +2,16 @@
 // Step-1 box (AnnotateSeatmap) and the fullscreen overlay (FullscreenAnnotate).
 //
 // It carries ONLY the marking technique: a react-zoom-pan-pinch zoom/pan
-// container + the surface-pixel ↔ normalized {x,y} conversion + counter-scaling
-// so the vermilion dot keeps a constant on-screen size as you zoom, plus the
-// ⊕ ⊖ ⟲ zoom controls and the top-left helper line. It fills its parent (the
-// parent owns framing: the inline box's aspect-[3/2]+border, or the overlay's
-// flex-1 region). Place/drag emits a normalized {x,y} in 0..1 (photos.x_percent
-// space) via onChange; undo/confirm live in the parent so the two surfaces stay
-// in sync off ONE shared point.
+// container + the click ↔ normalized {x,y} conversion + counter-scaling so the
+// vermilion dot keeps a constant on-screen size as you zoom, plus the ⊕ ⊖ ⟲
+// zoom controls and the top-left helper line. It fills its parent (the parent
+// owns framing: the inline box's aspect-[3/2]+border, or the overlay's flex-1
+// region) and the chart object-contains within it. Coordinates are normalized
+// against the chart's REAL content rect (image-rect.ts), not the frame, so the
+// surface works in ANY aspect ratio — a tap in the letterbox slack is rejected.
+// Place/drag emits {x,y} in 0..1 (photos.x_percent space) via onChange;
+// undo/confirm live in the parent so the two surfaces stay in sync off ONE
+// shared point.
 
 import { useCallback, useRef, useState } from "react";
 import {
@@ -20,6 +23,8 @@ import { Minus, Plus, RotateCcw } from "lucide-react";
 import type { Locale } from "@/i18n/config";
 import { useLocale } from "@/hooks/useLocale";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { useElementSize } from "@/hooks/useElementSize";
+import { imageContentRect } from "@/lib/image-rect";
 import type { SubMap } from "@/types";
 import { cn } from "@/lib/utils";
 
@@ -58,24 +63,48 @@ export default function MarkSurface({
 
   const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
   const surfaceRef = useRef<HTMLDivElement>(null);
+  // Unscaled outer box (NOT the transformed content) → the object-contain image
+  // content rect for positioning the dot. Re-measured on resize / fullscreen.
+  const outerRef = useRef<HTMLDivElement>(null);
+  const outerSize = useElementSize(outerRef);
   const [scale, setScale] = useState(MIN_SCALE);
   const draggingRef = useRef(false);
 
-  // Convert a client (pointer) position into a normalized 0..1 surface coord,
-  // accounting for the current pan/zoom transform of the content box.
+  // The object-contain image rectangle inside the unscaled outer box (the dot
+  // anchors to THIS, not the whole frame): x_percent/y_percent are normalized
+  // against the image's real content, so the letterbox slack must be excluded.
+  const contentRect = imageContentRect(
+    outerSize.width,
+    outerSize.height,
+    subMap.width,
+    subMap.height,
+  );
+
+  // Convert a client (pointer) position into a normalized 0..1 coord relative to
+  // the IMAGE CONTENT rectangle (u,v → a real pixel u·width, v·height on the
+  // chart), not the render frame. surfaceRef wraps the already scaled+panned
+  // content, so its rect is the rendered image box; object-contain geometry is
+  // proportional, so the content rect within that scaled rect is found with the
+  // same imageContentRect math. A tap in the letterbox slack (u/v outside 0..1)
+  // is rejected.
   const toNormalized = useCallback(
     (clientX: number, clientY: number): AnnotationPoint | null => {
       const surface = surfaceRef.current;
       if (!surface) return null;
       const rect = surface.getBoundingClientRect();
-      // surfaceRef wraps the (already transformed) content, so its rect IS the
-      // rendered, scaled+panned image box. Normalize within it.
-      const x = (clientX - rect.left) / rect.width;
-      const y = (clientY - rect.top) / rect.height;
-      if (x < 0 || x > 1 || y < 0 || y > 1) return null;
-      return { x: clamp01(x), y: clamp01(y) };
+      const cr = imageContentRect(
+        rect.width,
+        rect.height,
+        subMap.width,
+        subMap.height,
+      );
+      if (cr.width <= 0 || cr.height <= 0) return null;
+      const u = (clientX - rect.left - cr.offsetX) / cr.width;
+      const v = (clientY - rect.top - cr.offsetY) / cr.height;
+      if (u < 0 || u > 1 || v < 0 || v > 1) return null;
+      return { x: clamp01(u), y: clamp01(v) };
     },
-    [],
+    [subMap.width, subMap.height],
   );
 
   // Click/tap to place. Skipped while a drag just happened (the drag handler
@@ -119,8 +148,24 @@ export default function MarkSurface({
     [toNormalized, onChange],
   );
 
+  // Convert the image-relative (u,v) point into a percentage of the UNSCALED
+  // content box (= outerSize, the layer the dot lives on inside TransformComponent),
+  // folding the letterbox offset back in so the dot lands on the real pixel.
+  const dotLeftPct =
+    outerSize.width > 0
+      ? ((contentRect.offsetX + (point?.x ?? 0) * contentRect.width) /
+          outerSize.width) *
+        100
+      : (point?.x ?? 0) * 100;
+  const dotTopPct =
+    outerSize.height > 0
+      ? ((contentRect.offsetY + (point?.y ?? 0) * contentRect.height) /
+          outerSize.height) *
+        100
+      : (point?.y ?? 0) * 100;
+
   return (
-    <div className="relative size-full overflow-hidden">
+    <div ref={outerRef} className="relative size-full overflow-hidden">
       <TransformWrapper
         ref={transformRef}
         minScale={MIN_SCALE}
@@ -156,8 +201,8 @@ export default function MarkSurface({
                 onPointerDown={handleDotPointerDown}
                 className="group pointer-events-auto absolute grid size-11 cursor-grab place-items-center rounded-full focus-visible:outline-none active:cursor-grabbing"
                 style={{
-                  left: `${point.x * 100}%`,
-                  top: `${point.y * 100}%`,
+                  left: `${dotLeftPct}%`,
+                  top: `${dotTopPct}%`,
                   // Center on the anchor + counter-scale so the dot stays a
                   // constant on-screen size as the user zooms (same technique as
                   // the main seatmap). Centering MUST live only in this inline

--- a/src/lib/cluster.ts
+++ b/src/lib/cluster.ts
@@ -28,12 +28,13 @@ export const CLUSTER_TUNING = {
   MIN_THRESHOLD_PX: 2,
 } as const;
 
-/** A point laid out on the (unscaled) image surface, in pixels. */
+/** A point laid out on the (unscaled) image surface, in real chart pixels. */
 export interface LaidOutPoint {
   photo: PhotoDto;
-  /** Pixel x on the image surface (xPercent * imageWidth). */
+  /** Real pixel x on the chart image (xPercent * imageWidth — xPercent is now
+   *  image-content-relative, so this is a true pixel position). */
   x: number;
-  /** Pixel y on the image surface (yPercent * imageHeight). */
+  /** Real pixel y on the chart image (yPercent * imageHeight). */
   y: number;
 }
 

--- a/src/lib/image-rect.ts
+++ b/src/lib/image-rect.ts
@@ -1,0 +1,51 @@
+// object-contain geometry — the shared math behind the new annotation-coordinate
+// semantics (task 05-27-image-relative-coords).
+//
+// `photos.x_percent` / `y_percent` are normalized 0..1 against the image's REAL
+// content rectangle (u·subMap.width, v·subMap.height = a true pixel on the chart),
+// NOT against the render frame. So every read/write path needs to know where the
+// object-contain image actually sits inside its container (the letterbox offset
+// + the rendered content size). This is pure geometry — no DOM, no
+// `img.naturalWidth` — driven entirely by the container size and the sub-map's
+// stored intrinsic pixels, so it works identically on the server and the client.
+
+/** The real on-screen rectangle an object-contain image occupies in a container. */
+export interface ContentRect {
+  /** Letterbox offset from the container's left edge, px (0 on the tight axis). */
+  offsetX: number;
+  /** Letterbox offset from the container's top edge, px. */
+  offsetY: number;
+  /** Rendered width of the image content, px (<= containerW). */
+  width: number;
+  /** Rendered height of the image content, px (<= containerH). */
+  height: number;
+}
+
+/**
+ * Given a container size and the image's natural (intrinsic) size, compute the
+ * rectangle the image occupies when rendered with `object-contain` (scaled to
+ * fit, centered, letterboxed on the slack axis).
+ *
+ * Pure function: `containerW/H` may come from `getBoundingClientRect()` or from a
+ * fixed layout ratio. Degenerate inputs (<= 0) fall back to the full container so
+ * callers never divide by zero.
+ */
+export function imageContentRect(
+  containerW: number,
+  containerH: number,
+  naturalW: number,
+  naturalH: number,
+): ContentRect {
+  if (naturalW <= 0 || naturalH <= 0 || containerW <= 0 || containerH <= 0) {
+    return { offsetX: 0, offsetY: 0, width: containerW, height: containerH };
+  }
+  const scale = Math.min(containerW / naturalW, containerH / naturalH);
+  const width = naturalW * scale;
+  const height = naturalH * scale;
+  return {
+    offsetX: (containerW - width) / 2,
+    offsetY: (containerH - height) / 2,
+    width,
+    height,
+  };
+}

--- a/src/types/venue.ts
+++ b/src/types/venue.ts
@@ -50,9 +50,13 @@ export interface Photo {
   id: string;
   venueId: string;
   subMapId: string;
-  /** Normalized annotation coordinate, 0.0 ~ 1.0. */
+  /**
+   * Normalized annotation coordinate 0..1, relative to the chart image's REAL
+   * content rectangle (u·subMap.width = a true pixel on the chart), NOT the
+   * render frame. Decoupled from the display container's aspect ratio.
+   */
   xPercent: number;
-  /** Normalized annotation coordinate, 0.0 ~ 1.0. */
+  /** Normalized annotation coordinate 0..1, relative to the image content rect. */
   yPercent: number;
   /** R2 object key. */
   imageKey: string;


### PR DESCRIPTION
## Summary

issue #16 的**根本修复**（此前 #22 是治标——让全屏屈从 3:2 框）。

**病根**：`x_percent`/`y_percent` 旧语义是「相对固定 3:2 渲染框归一化（含 object-contain letterbox）」。底图非 3:2（k-arena 2048×939、ariake 1755×2048、belluna 2048×2048…）时，坐标把 letterbox 也编码进去——主图与内嵌框都是 3:2 故「自洽地错」，全屏（非 3:2 框）一暴露就偏移。

**根治**：坐标改为「相对图片真实矩形归一化」，与容器比例彻底解耦。
- 新增 `src/lib/image-rect.ts` 的 `imageContentRect()` 作为**唯一几何来源**
- 标点输入(`MarkSurface.toNormalized`)、标点显示、主图 pin/cluster、`focusCluster` 全部经它换算
- 新增 `useElementSize`（ResizeObserver）实时拿未缩放容器尺寸 → resize / 全屏开合安全；counter-scale 保留
- `FullscreenAnnotate` 删掉 #22 的 3:2 contain box → **真全屏**
- `cluster.ts` 聚合算法未改（本就在真实像素空间）

## 关联 & 部署顺序

- 配套数据迁移脚本：#23（已存 `x_percent` 是旧语义，**本 PR 部署后**再对 prod 跑迁移）
- 合并本 PR = 触发生产部署。发布序：合并本 PR → 部署生效 → 跑 #23 的脚本 `--remote`

## Test plan

- [x] 浏览器实测（k-arena 2048×939 宽图）：全屏 surface 比例 2.207（真全屏、非 3:2）；点击图片内容矩形 30%/40% → 读回 (u,v)=0.2998/0.3996；全屏↔内嵌对同一 point 落图一致
- [x] trellis-check：渲染 `imageContentRect` 与迁移逆变换数学一致（往返误差 1e-16）；spec 合规；无回归（PhotoGrid/Lightbox/服务端/AnnotateSeatmap 未受影响）
- [x] `astro check` 0 错 + prettier 通过
- [ ] 合并部署后，配合 #23 迁移，prod 非 3:2 底图标点精确落图