### PR TITLE
fix(scripts): 迁移脚本去掉 SQL 显式事务（D1 --remote 兼容）

### DIFF
--- a/scripts/migrate-coords-frame-to-image.mjs
+++ b/scripts/migrate-coords-frame-to-image.mjs
@@ -306,9 +306,15 @@ async function runForward({ remote, dryRun, force }) {
   );
   console.log(`\nBackup written: ${backupPath} (${rows.length} rows)`);
 
-  // Build one SQL file: per-id UPDATE (coords only — schema is NOT touched) in a
-  // transaction.
-  const sqlLines = ["BEGIN TRANSACTION;"];
+  // Build one SQL file: per-id UPDATE (coords only — schema is NOT touched).
+  // NO explicit `BEGIN TRANSACTION; ... COMMIT;`: real D1 (`--remote`) REJECTS
+  // SQL-level transactions ("To execute a transaction, please use the
+  // state.storage.transaction() ... instead of the SQL BEGIN TRANSACTION"). The
+  // local miniflare/sqlite ALLOWS them, so a local-only test does NOT surface
+  // this — it caused the first prod migration to fail at the BEGIN line.
+  // Atomicity is preserved anyway: `wrangler d1 execute --file` runs all the
+  // file's statements as ONE implicit batch (all-or-nothing).
+  const sqlLines = [];
   for (const u of updates) {
     sqlLines.push(
       `UPDATE photos SET x_percent = ${sqlNum(u.u)}, y_percent = ${sqlNum(
@@ -316,7 +322,6 @@ async function runForward({ remote, dryRun, force }) {
       )} WHERE id = '${u.id}';`,
     );
   }
-  sqlLines.push("COMMIT;");
 
   const sqlPath = join(backupsDir, `coords-migrate-${ts}.sql`);
   await writeFile(sqlPath, sqlLines.join("\n") + "\n", "utf8");
@@ -359,7 +364,9 @@ async function runRollback({ remote, backupFile }) {
   );
 
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
-  const sqlLines = ["BEGIN TRANSACTION;"];
+  // No explicit SQL transaction: D1 `--remote` rejects BEGIN/COMMIT (see the
+  // forward path). `d1 execute --file` runs the file as one atomic batch.
+  const sqlLines = [];
   for (const row of raw.rows) {
     // Restore old coords (schema is untouched — nothing else to reset).
     sqlLines.push(
@@ -368,7 +375,6 @@ async function runRollback({ remote, backupFile }) {
       )} WHERE id = '${row.id}';`,
     );
   }
-  sqlLines.push("COMMIT;");
 
   await mkdir(backupsDir, { recursive: true });
   const sqlPath = join(backupsDir, `coords-rollback-${ts}.sql`);


### PR DESCRIPTION
## Summary

#23 的迁移脚本对 prod 跑 `--remote` 首次失败：D1 `--remote` 禁止 SQL 级 `BEGIN TRANSACTION/COMMIT`（报错要求改用 `state.storage.transaction()`）。本地 miniflare/sqlite 允许该语法，故 `--local` 验证未暴露这个 local/remote 差异。

**修复**：去掉生成 SQL 里的 `BEGIN/COMMIT`，依赖 `wrangler d1 execute --file` 的隐式 batch 原子性（all-or-nothing）。

prod 24 行已用修复版**成功迁移并校验**（k-arena L5 y→0.4034、keio default x→0.3797，schema 未动）。本 PR 仅把正确版脚本补进 main，避免留坑。

## Test plan

- [x] prod `--remote` 迁移成功 + 抽样校验
- [x] 本地 D1 重新验证：apply / journal 拦截 / rollback 全过
- [x] `node --check` + prettier