### PR TITLE
fix(frontend): prevent seatmap pin drift on sub-map switches

### DIFF
--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -1,4 +1,10 @@
-import { useEffect, useState, type RefObject } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  type RefCallback,
+} from "react";
 
 // Track an element's rendered (CSS) size as a React value, kept fresh by a
 // ResizeObserver. Used by the seatmap + the upload mark surface to know the
@@ -15,32 +21,49 @@ export interface ElementSize {
 const ZERO: ElementSize = { width: 0, height: 0 };
 
 /**
- * Observe `ref`'s border-box size. Returns `{0,0}` until the element mounts and
- * the first observation fires (callers fall back to the full container, so a
- * single pre-measure frame renders harmlessly).
+ * Observe the current node's content-box size. A callback ref is intentional:
+ * seatmap branches can replace the measured DOM node (for example empty state
+ * -> loaded state), and a stable RefObject would keep observing the old node.
  */
-export function useElementSize(
-  ref: RefObject<HTMLElement | null>,
-): ElementSize {
+export function useElementSize<T extends HTMLElement = HTMLElement>(): [
+  RefCallback<T>,
+  ElementSize,
+] {
+  const [element, setElement] = useState<T | null>(null);
   const [size, setSize] = useState<ElementSize>(ZERO);
+  const ref = useCallback<RefCallback<T>>((node) => {
+    setElement(node);
+  }, []);
 
-  useEffect(() => {
-    const el = ref.current;
-    if (!el || typeof ResizeObserver === "undefined") return;
+  useIsomorphicLayoutEffect(() => {
+    if (!element) {
+      setSize(ZERO);
+      return;
+    }
 
+    const measure = () => {
+      const rect = element.getBoundingClientRect();
+      setSize({ width: rect.width, height: rect.height });
+    };
+
+    // Seed before paint on the client so coordinate overlays do not spend a
+    // visible frame in the unmeasured fallback.
+    measure();
+
+    if (typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (!entry) return;
       const rect = entry.contentRect;
       setSize({ width: rect.width, height: rect.height });
     });
-    observer.observe(el);
-    // Seed synchronously so the first paint has real dimensions where possible.
-    const rect = el.getBoundingClientRect();
-    setSize({ width: rect.width, height: rect.height });
+    observer.observe(element);
 
     return () => observer.disconnect();
-  }, [ref]);
+  }, [element]);
 
-  return size;
+  return [ref, size];
 }
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;

--- a/src/islands/Seatmap.tsx
+++ b/src/islands/Seatmap.tsx
@@ -35,6 +35,8 @@ import LoadFailure from "@/components/LoadFailure";
 
 const MIN_SCALE = 1;
 const MAX_SCALE = 6;
+const FRAME_FALLBACK_WIDTH = 1.5;
+const FRAME_FALLBACK_HEIGHT = 1;
 /** Zoom multiplier applied when a cluster is clicked (shape §7: ×2). */
 const CLUSTER_ZOOM_FACTOR = 2;
 /** Programmatic-zoom animation duration (ms). 0 when reduced-motion. */
@@ -76,10 +78,17 @@ export default function Seatmap({
   const reducedMotion = usePrefersReducedMotion();
 
   const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
-  const wrapperRef = useRef<HTMLDivElement>(null);
+  const wrapperNodeRef = useRef<HTMLDivElement | null>(null);
   // Unscaled frame box (NOT the zoom/pan-transformed layer) → the object-contain
   // chart-image content rect that pins anchor to. Re-measured on resize.
-  const wrapperSize = useElementSize(wrapperRef);
+  const [observeWrapper, wrapperSize] = useElementSize<HTMLDivElement>();
+  const setWrapperRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      wrapperNodeRef.current = node;
+      observeWrapper(node);
+    },
+    [observeWrapper],
+  );
 
   // Live transform state, driven by onTransformed. Drives clustering threshold,
   // counter-scaling, and the scale indicator.
@@ -134,7 +143,7 @@ export default function Seatmap({
   const focusCluster = useCallback(
     (cluster: Cluster) => {
       const api = transformRef.current;
-      const wrapper = wrapperRef.current;
+      const wrapper = wrapperNodeRef.current;
       if (!api || !wrapper) return;
 
       const targetScale = Math.min(scale * CLUSTER_ZOOM_FACTOR, MAX_SCALE);
@@ -201,7 +210,7 @@ export default function Seatmap({
 
   return (
     <SeatmapFrame subMapId={subMap.id}>
-      <div ref={wrapperRef} className="absolute inset-0">
+      <div ref={setWrapperRef} className="absolute inset-0">
         <TransformWrapper
           ref={transformRef}
           minScale={MIN_SCALE}
@@ -336,14 +345,16 @@ export default function Seatmap({
  * A cluster lives at image pixel (cluster.x, cluster.y). The overlay layer fills
  * the UNSCALED frame (wrapperSize), but the chart is object-contain within it, so
  * a pin's percent position is (contentOffset + imageFraction·contentSize) over
- * the frame extent. Before the frame is measured we fall back to the raw image
- * fraction (correct for a 3:2 frame on a 3:2 chart, harmless for one frame). */
+ * the frame extent. Before the frame is measured, use SeatmapFrame's known 3:2
+ * ratio so SSR and first client paint use the same coordinate contract. */
 function clusterPctX(
   cluster: Cluster,
   subMap: SubMap,
   frame: { width: number; height: number },
 ): number {
-  if (frame.width <= 0) return (cluster.x / subMap.width) * 100;
+  if (frame.width <= 0 || frame.height <= 0) {
+    return fallbackFramePct(cluster.x / subMap.width, "x", subMap);
+  }
   const cr = imageContentRect(
     frame.width,
     frame.height,
@@ -360,7 +371,9 @@ function clusterPctY(
   subMap: SubMap,
   frame: { width: number; height: number },
 ): number {
-  if (frame.height <= 0) return (cluster.y / subMap.height) * 100;
+  if (frame.width <= 0 || frame.height <= 0) {
+    return fallbackFramePct(cluster.y / subMap.height, "y", subMap);
+  }
   const cr = imageContentRect(
     frame.width,
     frame.height,
@@ -371,6 +384,23 @@ function clusterPctY(
     ((cr.offsetY + (cluster.y / subMap.height) * cr.height) / frame.height) *
     100
   );
+}
+
+function fallbackFramePct(
+  fraction: number,
+  axis: "x" | "y",
+  subMap: SubMap,
+): number {
+  const cr = imageContentRect(
+    FRAME_FALLBACK_WIDTH,
+    FRAME_FALLBACK_HEIGHT,
+    subMap.width,
+    subMap.height,
+  );
+  if (axis === "x") {
+    return ((cr.offsetX + fraction * cr.width) / FRAME_FALLBACK_WIDTH) * 100;
+  }
+  return ((cr.offsetY + fraction * cr.height) / FRAME_FALLBACK_HEIGHT) * 100;
 }
 
 /* ── Subcomponents ──────────────────────────────────────────────────────── */

--- a/src/islands/VenueMain.tsx
+++ b/src/islands/VenueMain.tsx
@@ -75,7 +75,13 @@ export default function VenueMain({
   );
   const [photosLoading, setPhotosLoading] = useState(false);
   const [photosError, setPhotosError] = useState(false);
-  const photosSubMapRef = useRef<string | undefined>(initialActiveId);
+  // Tracks the currently intended client fetch. A request id is needed because
+  // retrying the same sub-map can otherwise make an older response look fresh.
+  const photosRequestSeqRef = useRef(0);
+  const photosRequestRef = useRef<{
+    id: number;
+    subMapId: string;
+  } | null>(null);
 
   useEffect(() => {
     function onChange(event: Event) {
@@ -87,25 +93,34 @@ export default function VenueMain({
   }, []);
 
   // Fetch the full point set for a sub-map. Reused by the sub-map-change effect
-  // and the seatmap's <LoadFailure> retry (error-pages §4). `cancelledRef` is a
-  // ref so the retry path can guard against a stale resolution too.
+  // and the seatmap's <LoadFailure> retry (error-pages §4). The request ref
+  // keeps same-sub-map retries loading until the active request settles.
   const loadPoints = useCallback(
     (subMapId: string) => {
-      photosSubMapRef.current = subMapId;
+      const requestId = photosRequestSeqRef.current + 1;
+      photosRequestSeqRef.current = requestId;
+      photosRequestRef.current = { id: requestId, subMapId };
+
+      const isCurrentRequest = () =>
+        photosRequestRef.current?.id === requestId &&
+        photosRequestRef.current.subMapId === subMapId;
+
       setPhotosLoading(true);
       setPhotosError(false);
       fetchSubMapPhotos(venue.id, subMapId)
         .then((next) => {
-          if (photosSubMapRef.current !== subMapId) return;
+          if (!isCurrentRequest()) return;
           setPhotos(next);
           setPhotosSubMapId(subMapId);
+          photosRequestRef.current = null;
           setPhotosLoading(false);
         })
         .catch(() => {
-          if (photosSubMapRef.current !== subMapId) return;
+          if (!isCurrentRequest()) return;
           setPhotos([]);
           setPhotosSubMapId(subMapId);
           setPhotosError(true);
+          photosRequestRef.current = null;
           setPhotosLoading(false);
         });
     },
@@ -117,11 +132,17 @@ export default function VenueMain({
   useEffect(() => {
     if (!activeSubMapId) return;
     if (activeSubMapId === photosSubMapId) {
-      photosSubMapRef.current = activeSubMapId;
+      if (photosRequestRef.current?.subMapId === activeSubMapId) return;
+      photosRequestRef.current = null;
       if (photosLoading) setPhotosLoading(false);
       return;
     }
-    if (activeSubMapId === photosSubMapRef.current && photosLoading) return;
+    if (
+      photosLoading &&
+      photosRequestRef.current?.subMapId === activeSubMapId
+    ) {
+      return;
+    }
     loadPoints(activeSubMapId);
   }, [activeSubMapId, photosLoading, photosSubMapId, loadPoints]);
 

--- a/src/islands/VenueMain.tsx
+++ b/src/islands/VenueMain.tsx
@@ -70,6 +70,9 @@ export default function VenueMain({
   // Full annotation set for the active sub-map (the seatmap needs ALL points to
   // cluster). Seeded with the SSR set; re-fetched on sub-map change.
   const [photos, setPhotos] = useState<PhotoDto[]>(initialPhotos);
+  const [photosSubMapId, setPhotosSubMapId] = useState<string | undefined>(
+    initialActiveId,
+  );
   const [photosLoading, setPhotosLoading] = useState(false);
   const [photosError, setPhotosError] = useState(false);
   const photosSubMapRef = useRef<string | undefined>(initialActiveId);
@@ -88,16 +91,20 @@ export default function VenueMain({
   // ref so the retry path can guard against a stale resolution too.
   const loadPoints = useCallback(
     (subMapId: string) => {
+      photosSubMapRef.current = subMapId;
       setPhotosLoading(true);
       setPhotosError(false);
       fetchSubMapPhotos(venue.id, subMapId)
         .then((next) => {
           if (photosSubMapRef.current !== subMapId) return;
           setPhotos(next);
+          setPhotosSubMapId(subMapId);
           setPhotosLoading(false);
         })
         .catch(() => {
           if (photosSubMapRef.current !== subMapId) return;
+          setPhotos([]);
+          setPhotosSubMapId(subMapId);
           setPhotosError(true);
           setPhotosLoading(false);
         });
@@ -109,10 +116,10 @@ export default function VenueMain({
   // the first run for the SSR-seeded sub-map to avoid a double fetch.
   useEffect(() => {
     if (!activeSubMapId) return;
-    if (activeSubMapId === photosSubMapRef.current) return;
-    photosSubMapRef.current = activeSubMapId;
+    if (activeSubMapId === photosSubMapId) return;
+    if (activeSubMapId === photosSubMapRef.current && photosLoading) return;
     loadPoints(activeSubMapId);
-  }, [activeSubMapId, loadPoints]);
+  }, [activeSubMapId, photosLoading, photosSubMapId, loadPoints]);
 
   // Seatmap <LoadFailure> retry → re-run the active sub-map's point fetch.
   const handleRetryPoints = useCallback(() => {
@@ -125,6 +132,9 @@ export default function VenueMain({
 
   const activeSubMap =
     venue.subMaps.find((s) => s.id === activeSubMapId) ?? venue.subMaps[0];
+  const photosMatchActive = activeSubMap?.id === photosSubMapId;
+  const activePhotos = photosMatchActive ? photos : [];
+  const activePhotosLoading = photosLoading || !photosMatchActive;
 
   // ── Lightbox: one instance, two modes ─────────────────────────────────────
   const [lightboxRequest, setLightboxRequest] =
@@ -134,11 +144,11 @@ export default function VenueMain({
   // `photos`; find the clicked one and open with just it (no paging).
   const handleOpenLightbox = useCallback(
     (photoId: string) => {
-      const photo = photos.find((p) => p.id === photoId);
+      const photo = activePhotos.find((p) => p.id === photoId);
       if (!photo) return;
       setLightboxRequest({ mode: "single", photos: [photo], index: 0 });
     },
-    [photos],
+    [activePhotos],
   );
 
   // Grid card → SEQUENCE mode (browse this sub-map). The grid hands over the
@@ -173,6 +183,7 @@ export default function VenueMain({
   // seatmap shows the new pin immediately, and bump the grid key so the grid
   // re-pulls newest-first from the API (also picks up anyone else's uploads).
   const handleUploaded = useCallback((photo: PhotoDto) => {
+    setPhotosSubMapId(photo.subMapId);
     setPhotos((prev) =>
       prev.some((p) => p.id === photo.id) ? prev : [photo, ...prev],
     );
@@ -190,9 +201,9 @@ export default function VenueMain({
         <Seatmap
           locale={locale}
           subMap={activeSubMap}
-          photos={photos}
-          loading={photosLoading}
-          error={photosError}
+          photos={activePhotos}
+          loading={activePhotosLoading}
+          error={photosMatchActive && photosError}
           selectedPhotoId={selectedPhotoId}
           onOpenLightbox={handleOpenLightbox}
           onRetry={handleRetryPoints}

--- a/src/islands/VenueMain.tsx
+++ b/src/islands/VenueMain.tsx
@@ -116,7 +116,11 @@ export default function VenueMain({
   // the first run for the SSR-seeded sub-map to avoid a double fetch.
   useEffect(() => {
     if (!activeSubMapId) return;
-    if (activeSubMapId === photosSubMapId) return;
+    if (activeSubMapId === photosSubMapId) {
+      photosSubMapRef.current = activeSubMapId;
+      if (photosLoading) setPhotosLoading(false);
+      return;
+    }
     if (activeSubMapId === photosSubMapRef.current && photosLoading) return;
     loadPoints(activeSubMapId);
   }, [activeSubMapId, photosLoading, photosSubMapId, loadPoints]);

--- a/src/islands/VenueMain.tsx
+++ b/src/islands/VenueMain.tsx
@@ -106,12 +106,12 @@ export default function VenueMain({
         photosRequestRef.current.subMapId === subMapId;
 
       setPhotosLoading(true);
-      setPhotosError(false);
       fetchSubMapPhotos(venue.id, subMapId)
         .then((next) => {
           if (!isCurrentRequest()) return;
           setPhotos(next);
           setPhotosSubMapId(subMapId);
+          setPhotosError(false);
           photosRequestRef.current = null;
           setPhotosLoading(false);
         })
@@ -228,7 +228,7 @@ export default function VenueMain({
           subMap={activeSubMap}
           photos={activePhotos}
           loading={activePhotosLoading}
-          error={photosMatchActive && photosError}
+          error={photosMatchActive && photosError && !photosLoading}
           selectedPhotoId={selectedPhotoId}
           onOpenLightbox={handleOpenLightbox}
           onRetry={handleRetryPoints}

--- a/src/islands/upload/MarkSurface.tsx
+++ b/src/islands/upload/MarkSurface.tsx
@@ -65,8 +65,7 @@ export default function MarkSurface({
   const surfaceRef = useRef<HTMLDivElement>(null);
   // Unscaled outer box (NOT the transformed content) → the object-contain image
   // content rect for positioning the dot. Re-measured on resize / fullscreen.
-  const outerRef = useRef<HTMLDivElement>(null);
-  const outerSize = useElementSize(outerRef);
+  const [outerRef, outerSize] = useElementSize<HTMLDivElement>();
   const [scale, setScale] = useState(MIN_SCALE);
   const draggingRef = useRef(false);
 


### PR DESCRIPTION
## Summary
- keep seatmap annotations tied to the sub-map that loaded them so stale pins are not drawn on a newly selected chart
- measure the currently mounted seatmap wrapper through a callback ref so empty/loaded branch swaps re-bind ResizeObserver
- use the 3:2 seatmap frame content-rect fallback before measurement so SSR and first client paint follow the image-relative coordinate contract

Fixes #26

## Verification
- npm run format:check
- npm run typecheck
- npm run build
- Playwright smoke check on K Arena Yokohama: L1 pins align within <1px after initial load and after switching through an empty mocked sub-map