### PR TITLE
feat(links): 友链页面 + footer 入口 (#32)

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -46,6 +46,12 @@ const githubRepo = "https://github.com/Sallyn0225/seatview";
       >
       <span aria-hidden="true">·</span>
       <a
+        href={`/${locale}/links`}
+        class="hover:text-foreground focus-visible:ring-ring rounded-sm focus-visible:ring-2 focus-visible:outline-none"
+        >{t.footer.links}</a
+      >
+      <span aria-hidden="true">·</span>
+      <a
         href={`/${locale}/privacy`}
         class="hover:text-foreground focus-visible:ring-ring rounded-sm focus-visible:ring-2 focus-visible:outline-none"
         >{t.footer.privacy}</a

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -194,6 +194,7 @@ const en: Messages = {
     about: "About",
     privacy: "Privacy",
     terms: "Terms",
+    links: "Links",
     copyright: "© SeatView · Real Seat Views",
     navLabel: "Footer",
   },
@@ -247,6 +248,15 @@ const en: Messages = {
     updated: "Last updated: {date}",
     feedback: "Questions or correction requests? Reach us via {github}.",
     feedbackLink: "the GitHub repo",
+  },
+  links: {
+    title: "Links",
+    intro:
+      "A few related projects the maintainer built, plus some sites from friends in the community.",
+    groupMine: "My projects",
+    subGenchi: "On-site guides",
+    subFun: "Fun & games",
+    groupFriends: "Friend links",
   },
   home: {
     subtitle: "Real Seat Views",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -185,6 +185,7 @@ const ja: Messages = {
     about: "このサイトについて",
     privacy: "プライバシー",
     terms: "利用規約",
+    links: "リンク集",
     copyright: "© SeatView · リアル座席ビュー",
     navLabel: "フッター",
   },
@@ -238,6 +239,15 @@ const ja: Messages = {
     updated: "最終更新：{date}",
     feedback: "ご質問や訂正のご依頼は {github} からお寄せください。",
     feedbackLink: "GitHub リポジトリ",
+  },
+  links: {
+    title: "リンク集",
+    intro:
+      "管理者が手がけた関連プロジェクトと、仲間のサイトをいくつか置いています。",
+    groupMine: "自分のプロジェクト",
+    subGenchi: "現地関連",
+    subFun: "エンタメ関連",
+    groupFriends: "フレンドリンク",
   },
   home: {
     subtitle: "リアル座席ビュー",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -192,6 +192,7 @@ const ko: Messages = {
     about: "소개",
     privacy: "개인정보",
     terms: "이용약관",
+    links: "링크",
     copyright: "© SeatView · 실제 좌석 뷰",
     navLabel: "푸터",
   },
@@ -245,6 +246,14 @@ const ko: Messages = {
     updated: "마지막 업데이트: {date}",
     feedback: "질문이나 정정 요청은 {github}로 보내 주세요.",
     feedbackLink: "GitHub 저장소",
+  },
+  links: {
+    title: "링크",
+    intro: "관리자가 만든 관련 프로젝트와 동료들의 사이트를 모아 두었습니다.",
+    groupMine: "내 프로젝트",
+    subGenchi: "현지 관련",
+    subFun: "엔터테인먼트",
+    groupFriends: "프렌드 링크",
   },
   home: {
     subtitle: "실제 좌석 뷰",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -228,6 +228,8 @@ export interface Messages {
     about: string;
     privacy: string;
     terms: string;
+    /** Friend-links page nav label (issue #32). */
+    links: string;
     copyright: string;
     /** Footer `<nav>` aria-label. */
     navLabel: string;
@@ -252,6 +254,22 @@ export interface Messages {
     feedback: string;
     /** Link text for the GitHub repo inside `feedback`. */
     feedbackLink: string;
+  };
+  /** Standalone friend-links page (issue #32). Only the chrome is translated;
+   *  link names + URLs stay in their original (zh) form and live in the page. */
+  links: {
+    /** Page <h1> + browser title. */
+    title: string;
+    /** Lead paragraph. */
+    intro: string;
+    /** Group heading: the maintainer's own projects. */
+    groupMine: string;
+    /** Sub-group under groupMine: on-site (現地) related. */
+    subGenchi: string;
+    /** Sub-group under groupMine: entertainment / fun. */
+    subFun: string;
+    /** Group heading: other people's projects (friend links). */
+    groupFriends: string;
   };
   /** Home / intro page (shape-home-explainer.md). */
   home: {
@@ -597,6 +615,7 @@ const zh: Messages = {
     about: "关于",
     privacy: "隐私政策",
     terms: "服务条款",
+    links: "友链",
     copyright: "© SeatView · 真实视角图集",
     navLabel: "页脚",
   },
@@ -650,6 +669,14 @@ const zh: Messages = {
     updated: "最后更新：{date}",
     feedback: "如有疑问或更正请求，欢迎通过 {github} 反馈。",
     feedbackLink: "GitHub 仓库",
+  },
+  links: {
+    title: "友链",
+    intro: "这里收着我自己做的一些相关项目，和几个同好的友站。",
+    groupMine: "我自己的项目",
+    subGenchi: "现地相关",
+    subFun: "娱乐相关",
+    groupFriends: "友情链接",
   },
   home: {
     subtitle: "真实视角图集",

--- a/src/pages/[lang]/links.astro
+++ b/src/pages/[lang]/links.astro
@@ -1,0 +1,144 @@
+---
+// Standalone friend-links page (issue #32) — its own route, sibling to
+// privacy/terms. Static content; SSR on demand like the rest of /[lang]/.
+// Mirrors the LegalArticle shell (680px column, Sans-only, neutral, no 朱赤).
+// Chrome is translated; link names + URLs stay in their original (zh) form.
+import Layout from "@/layouts/Layout.astro";
+import SiteHeader from "@/components/SiteHeader.astro";
+import SiteFooter from "@/components/SiteFooter.astro";
+import { asLocale } from "@/i18n/config";
+import { getMessages } from "@/i18n";
+
+const locale = asLocale(Astro.params.lang);
+const t = getMessages(locale);
+
+interface LinkItem {
+  name: string;
+  url: string;
+}
+interface LinkGroup {
+  heading: string;
+  items?: LinkItem[];
+  subgroups?: { heading: string; items: LinkItem[] }[];
+}
+
+const linkGroups: LinkGroup[] = [
+  {
+    heading: t.links.groupMine,
+    subgroups: [
+      {
+        heading: t.links.subGenchi,
+        items: [
+          {
+            name: "一个从零到一的全流程日本现地攻略",
+            url: "https://arisa114514.feishu.cn/wiki/QCNOwAGPxiAE1Ak39BIcRlGbnjh",
+          },
+          {
+            name: "BDR现地攻略组 · 日本现地常用网站聚合站",
+            url: "https://genchi.top/",
+          },
+          {
+            name: "现地故事会",
+            url: "https://arisa114514.feishu.cn/wiki/LC0iwag6LitXZXk38D5csOAcn9f",
+          },
+        ],
+      },
+      {
+        heading: t.links.subFun,
+        items: [
+          {
+            name: "一个匹配你是283哪个小偶像的测试站",
+            url: "https://283ti.genchi.top/",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    heading: t.links.groupFriends,
+    items: [
+      { name: "北美炸梦同好会", url: "https://bangdream.org/" },
+      { name: "邦多利现场听歌统计", url: "https://bandori.live/" },
+    ],
+  },
+];
+
+const linkClass =
+  "text-foreground/90 hover:text-foreground focus-visible:ring-ring rounded-sm underline underline-offset-2 focus-visible:ring-2 focus-visible:outline-none";
+---
+
+<Layout locale={locale} title={`${t.links.title} · SeatView`}>
+  <div class="flex min-h-screen flex-col">
+    <SiteHeader locale={locale} />
+
+    <main class="flex-1">
+      <article class="mx-auto max-w-[680px] px-6 pt-12 pb-16 lg:pt-16">
+        <h1
+          class="text-foreground text-3xl font-bold tracking-tight lg:text-4xl"
+        >
+          {t.links.title}
+        </h1>
+        <p class="text-muted-foreground mt-4 text-base leading-relaxed">
+          {t.links.intro}
+        </p>
+
+        <div class="mt-10 space-y-10">
+          {
+            linkGroups.map((group) => (
+              <section>
+                <h2 class="text-foreground text-lg font-bold">
+                  {group.heading}
+                </h2>
+
+                {group.subgroups && (
+                  <div class="mt-4 space-y-6">
+                    {group.subgroups.map((sub) => (
+                      <div>
+                        <h3 class="text-muted-foreground text-sm font-semibold">
+                          {sub.heading}
+                        </h3>
+                        <ul class="mt-2 space-y-2">
+                          {sub.items.map((item) => (
+                            <li>
+                              <a
+                                href={item.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class={linkClass}
+                              >
+                                {item.name} ↗
+                              </a>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {group.items && (
+                  <ul class="mt-4 space-y-2">
+                    {group.items.map((item) => (
+                      <li>
+                        <a
+                          href={item.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class={linkClass}
+                        >
+                          {item.name} ↗
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            ))
+          }
+        </div>
+      </article>
+    </main>
+
+    <SiteFooter locale={locale} />
+  </div>
+</Layout>


### PR DESCRIPTION
## Summary

实现 issue #32：新增独立的「友链」页面（与 privacy/terms 同级的 `/[lang]/links` 路由），并在共享 footer 中加入跳转入口。

- **新页面** `src/pages/[lang]/links.astro`：沿用 `LegalArticle` 版式（680px 阅读列、Sans-only、中性色、零朱赤）。链接数据 locale 无关、硬编码，分两组：
  - 我自己的项目 → 现地相关（3 条）/ 娱乐相关（1 条）
  - 友情链接 → 平铺 2 条
  - 外链统一 `target="_blank" rel="noopener noreferrer"`
- **footer** `SiteFooter.astro`：nav 加「友链」入口，顺序 `GitHub · 关于 · 友链 · 隐私政策 · 服务条款`
- **i18n**：`Messages` 接口新增 `links` 段 + `footer.links`，四语言（zh/ja/en/ko）补齐。多语言策略 = **页面骨架翻译、链接文案保留中文**（现地攻略/同好友站为中文语境）

Closes #32

## Test plan

- [x] `npm run typecheck`（astro check）0 errors
- [x] `npm run format:check` 全绿
- [x] 浏览器验证 `/zh/links`：分组、链接 URL、footer 入口与跳转、无朱赤
- [x] 浏览器验证 `/ja/links`：骨架日文翻译、链接名保留中文、footer 入口翻译
- [ ] reviewer 复核 en/ko 文案