### PR TITLE
feat(staging): hide already-collected venues from public wishlist (#41)

### DIFF
--- a/src/islands/StagingForm.tsx
+++ b/src/islands/StagingForm.tsx
@@ -636,7 +636,6 @@ export default function StagingForm({
                 key={v.id}
                 venue={v}
                 locale={locale}
-                processedLabel={t.staging.processed}
                 votesLabel={t.staging.votes}
                 plusOneLabel={t.staging.plusOne}
                 plusOneDoneLabel={t.staging.plusOneDone}
@@ -699,7 +698,6 @@ export default function StagingForm({
 interface StagingRowProps {
   venue: StagingVenueDto;
   locale: Locale;
-  processedLabel: string;
   /** `{count}` template → "N 人想看" demand tally (need-signal, not a like). */
   votesLabel: string;
   /** "+1" button label. */
@@ -727,7 +725,6 @@ interface StagingRowProps {
 function StagingRow({
   venue,
   locale,
-  processedLabel,
   votesLabel,
   plusOneLabel,
   plusOneDoneLabel,
@@ -776,39 +773,31 @@ function StagingRow({
         <span className="text-muted-foreground text-xs [font-variant-numeric:tabular-nums]">
           {votesText}
         </span>
+        {/* The public wishlist never lists 已收录 venues (issue #41 filters them
+            in listStagingVenues), so every row here is un-collected and carries
+            the +1 / ✓ 已附议 control. */}
         <div className="flex shrink-0 items-center gap-3">
-          {venue.processed && (
-            // Sumi ink ✓ — never vermilion, never green (decision 2 派生).
+          {venue.votedByMe ? (
             <span className="text-foreground inline-flex items-center gap-1 text-xs">
               <span aria-hidden="true">✓</span>
-              {processedLabel}
+              {plusOneDoneLabel}
             </span>
+          ) : (
+            <button
+              type="button"
+              onClick={() => onPlusOne(venue.id)}
+              disabled={plusOneBlocked}
+              aria-label={plusOneAriaLabel.replace("{name}", venue.name)}
+              className={cn(
+                "border-border text-muted-foreground inline-flex h-8 shrink-0 items-center rounded-md border px-3 text-xs font-medium",
+                "transition-colors duration-150 hover:text-foreground hover:border-foreground/40",
+                "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+              )}
+            >
+              {plusOneLabel}
+            </button>
           )}
-          {/* 已收录 → no +1 affordance at all (issue #15); the ✓ 已收录 marker
-              above already states the terminal state. Only un-collected rows
-              carry the +1 / ✓ 已附议 control. */}
-          {!venue.processed &&
-            (venue.votedByMe ? (
-              <span className="text-foreground inline-flex items-center gap-1 text-xs">
-                <span aria-hidden="true">✓</span>
-                {plusOneDoneLabel}
-              </span>
-            ) : (
-              <button
-                type="button"
-                onClick={() => onPlusOne(venue.id)}
-                disabled={plusOneBlocked}
-                aria-label={plusOneAriaLabel.replace("{name}", venue.name)}
-                className={cn(
-                  "border-border text-muted-foreground inline-flex h-8 shrink-0 items-center rounded-md border px-3 text-xs font-medium",
-                  "transition-colors duration-150 hover:text-foreground hover:border-foreground/40",
-                  "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
-                  "disabled:cursor-not-allowed disabled:opacity-50",
-                )}
-              >
-                {plusOneLabel}
-              </button>
-            ))}
         </div>
       </div>
     </li>

--- a/src/pages/[lang]/staging.astro
+++ b/src/pages/[lang]/staging.astro
@@ -44,6 +44,7 @@ if (env.DB) {
     const rows = await listStagingVenues(getDb(env.DB), {
       limit: STAGING_BATCH + 1,
       viewerIpHash,
+      excludeProcessed: true, // hide 已收录 from the public wishlist (issue #41)
     });
     initialHasMore = rows.length > STAGING_BATCH;
     initialVenues = initialHasMore ? rows.slice(0, STAGING_BATCH) : rows;

--- a/src/pages/api/staging.ts
+++ b/src/pages/api/staging.ts
@@ -169,6 +169,7 @@ export const GET: APIRoute = async ({ request, url }) => {
       offset,
       limit: limit + 1,
       viewerIpHash,
+      excludeProcessed: true, // hide 已收录 from the public wishlist (issue #41)
     });
     const hasMore = rows.length > limit;
     const payload: StagingListResponse = {

--- a/src/server/staging.ts
+++ b/src/server/staging.ts
@@ -9,7 +9,7 @@
 // path carries Turnstile + KV limits in /api/staging, while +1 is bounded purely
 // in D1 (permanent per-venue dedup + a 5-different-venues/day cap).
 
-import { and, desc, eq, gte, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNull, sql } from "drizzle-orm";
 import type { Db } from "@/server/db";
 import type { StagingNameDto } from "@/lib/staging";
 import { newId } from "@/server/id";
@@ -45,6 +45,13 @@ export interface ListStagingOptions {
    * (e.g. unknown IP) → all `votedByMe` are false.
    */
   viewerIpHash?: string;
+  /**
+   * Drop already-collected rows (`processed_at IS NULL`, issue #41). The PUBLIC
+   * staging page passes this so a 已收录 venue stops cluttering the wishlist; the
+   * maintainer triage list omits it (admin still needs to see + manage them).
+   * Filtering in the query keeps offset paging self-consistent.
+   */
+  excludeProcessed?: boolean;
 }
 
 /** Default page size for the staging list (text-only rows are light, §11). */
@@ -64,6 +71,9 @@ export async function listStagingVenues(
   const rows = await db
     .select()
     .from(stagingVenues)
+    .where(
+      options.excludeProcessed ? isNull(stagingVenues.processedAt) : undefined,
+    )
     .orderBy(desc(stagingVenues.voteCount), desc(stagingVenues.createdAt))
     .limit(options.limit ?? STAGING_BATCH)
     .offset(options.offset ?? 0);


### PR DESCRIPTION
## Summary
- Already-collected (processed) venues cluttered the public 想看的场馆 wishlist and buried the un-collected ones users actually want to read (issue #41).
- Add an `excludeProcessed?` option to `listStagingVenues` that filters `processed_at IS NULL` at the query layer (keeps offset paging self-consistent).
- The public SSR page (`[lang]/staging.astro`) and `GET /api/staging` pass `excludeProcessed: true`; the maintainer triage list (`GET /api/admin/staging`) is unchanged and still sees + manages collected rows.
- The typing-time dedup hint (`/api/staging/names`) is intentionally left as-is — it keeps surfacing 已收录 matches so users don't re-submit an already-collected venue.
- Removed the now-dead `✓ 已收录` badge + `processedLabel` prop from `StagingRow` (the public list never contains processed rows anymore; `t.staging.processed` is still used by the dedup hint).

## Scope decision
Only the wishlist **list** hides collected venues; the dedup hint behavior is unchanged (confirmed with maintainer). Rationale: the `processed` flag and the actual atlas promotion (GitHub PR, R7.3) have a time gap, so the hint still guards against duplicate requests.

## Test plan
Verified locally against miniflare D1 (seeded 2 un-collected + 2 collected rows, then cleaned up):
- [x] `npm run typecheck` (astro check) — 0 errors
- [x] prettier — all touched files pass
- [x] Public SSR `/zh/staging` — only un-collected rows render (top-voted collected row correctly hidden)
- [x] Public `GET /api/staging` — returns only un-collected rows
- [x] Admin `GET /api/admin/staging` — still returns all rows incl. collected
- [x] `GET /api/staging/names` — dedup corpus still includes collected rows with `processed: true`

Closes #41