### PR TITLE
Fix issue #51 marker clustering transitivity

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "astro build",
     "preview": "astro build && wrangler dev -c dist/server/wrangler.json",
     "deploy": "astro build && wrangler deploy -c dist/server/wrangler.json",
-    "test": "node --test src/**/*.test.ts",
+    "test": "node --experimental-strip-types --test \"src/**/*.test.ts\"",
     "astro": "astro",
     "typecheck": "astro check",
     "format": "prettier --write \"src/**/*.{ts,tsx,astro,css}\" \"scripts/**/*.{mjs,js}\" \"*.{ts,mjs}\"",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "astro build",
     "preview": "astro build && wrangler dev -c dist/server/wrangler.json",
     "deploy": "astro build && wrangler deploy -c dist/server/wrangler.json",
+    "test": "node --test src/**/*.test.ts",
     "astro": "astro",
     "typecheck": "astro check",
     "format": "prettier --write \"src/**/*.{ts,tsx,astro,css}\" \"scripts/**/*.{mjs,js}\" \"*.{ts,mjs}\"",

--- a/src/lib/cluster.test.ts
+++ b/src/lib/cluster.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { clusterPoints, type LaidOutPoint } from "./cluster.ts";
+import type { PhotoDto } from "@/lib/photos";
+
+function point(id: string, x: number, y = 0): LaidOutPoint {
+  return {
+    photo: {
+      id,
+      venueId: "test-venue",
+      subMapId: "default",
+      xPercent: 0,
+      yPercent: 0,
+      imageKey: `${id}.webp`,
+      width: 100,
+      height: 100,
+      seatLabel: id,
+      performanceDate: null,
+      eventName: null,
+      description: null,
+      createdAt: 0,
+    } satisfies PhotoDto,
+    x,
+    y,
+  };
+}
+
+function memberSets(points: readonly LaidOutPoint[], scale: number): string[] {
+  return clusterPoints(points, scale)
+    .map((cluster) => cluster.members.map((member) => member.photo.id).sort())
+    .sort((a, b) => a[0]!.localeCompare(b[0]!))
+    .map((members) => members.join(","));
+}
+
+describe("clusterPoints", () => {
+  it("clusters transitive chains even when endpoints are beyond threshold", () => {
+    const points = [
+      point("a", 0),
+      point("b", 20),
+      point("c", 40),
+      point("d", 60),
+      point("e", 80),
+    ];
+
+    const clusters = clusterPoints(points, 1);
+
+    assert.equal(clusters.length, 1);
+    assert.deepEqual(
+      clusters[0]!.members.map((member) => member.photo.id),
+      ["a", "b", "c", "d", "e"],
+    );
+  });
+
+  it("returns the same member sets regardless of input order", () => {
+    const ordered = [
+      point("a", 0),
+      point("b", 20),
+      point("c", 40),
+      point("d", 120),
+      point("e", 140),
+    ];
+    const shuffled = [
+      ordered[3]!,
+      ordered[1]!,
+      ordered[4]!,
+      ordered[0]!,
+      ordered[2]!,
+    ];
+
+    assert.deepEqual(memberSets(shuffled, 1), memberSets(ordered, 1));
+  });
+
+  it("keeps distant tight groups as separate clusters", () => {
+    const points = [
+      point("a", 0),
+      point("b", 20),
+      point("c", 200),
+      point("d", 220),
+    ];
+
+    assert.deepEqual(memberSets(points, 1), ["a,b", "c,d"]);
+  });
+
+  it("splits points when zoom makes the threshold stricter than all distances", () => {
+    const points = [point("a", 0), point("b", 20), point("c", 40)];
+
+    assert.deepEqual(memberSets(points, 3), ["a", "b", "c"]);
+  });
+});

--- a/src/lib/cluster.ts
+++ b/src/lib/cluster.ts
@@ -11,18 +11,24 @@
 // a spatial grid (noted in frontend-libraries.md performance checkpoints).
 //
 // All magic numbers live in CLUSTER_TUNING so Q6 ("initial 75px/scale, tune
-// after seeing it") is a one-line change.
+// after seeing it") stays localized.
 
 import type { PhotoDto } from "@/lib/photos";
 
 export const CLUSTER_TUNING = {
   /**
-   * Base merge distance in image-surface pixels at scale 1. The effective
-   * surface threshold is `BASE_THRESHOLD_PX / scale²`: low zoom strongly groups
-   * close seat marks, while high zoom quickly separates them for clicking.
+   * Base merge distance in image-surface pixels at scale 1. Before the minimum
+   * floor applies, the effective surface threshold is
+   * `BASE_THRESHOLD_PX / scale²`: low zoom strongly groups close seat marks,
+   * while high zoom quickly separates them for clicking.
    */
   BASE_THRESHOLD_PX: 75,
-  /** Below this surface-pixel threshold, never shrink further. */
+  /**
+   * Floor for the first-stage threshold returned by `clusterThresholdPx`.
+   * `clusterPoints` still divides by scale before comparing image-surface
+   * distances, so at extreme zoom the effective surface threshold is
+   * `MIN_THRESHOLD_PX / scale`.
+   */
   MIN_THRESHOLD_PX: 2,
 } as const;
 
@@ -49,8 +55,9 @@ export interface Cluster {
 }
 
 /**
- * Compute the first-stage merge threshold for a given zoom scale. `clusterPoints`
- * divides this by scale again to compare image-surface distances.
+ * Compute the first-stage merge threshold for a given zoom scale. This value is
+ * floored by `MIN_THRESHOLD_PX`; `clusterPoints` divides it by scale again to
+ * compare image-surface distances.
  */
 export function clusterThresholdPx(scale: number): number {
   const safeScale = scale > 0 ? scale : 1;

--- a/src/lib/cluster.ts
+++ b/src/lib/cluster.ts
@@ -1,30 +1,28 @@
 // Annotation-point clustering for the seatmap (R3.5 / R3.6 / Open Question Q6).
 //
-// Points are clustered by SCREEN-pixel proximity, and the threshold shrinks as
-// the user zooms in (inverse to scale): two pins that overlap at scale 1 pull
-// apart and become individually clickable as you zoom. This is what makes the
-// "click cluster → zoom in → it explodes into single pins" flow work (ADR-4).
+// Points are clustered by image-surface proximity, and the threshold shrinks
+// quickly as the user zooms in: two pins that overlap at scale 1 pull apart and
+// become individually clickable as you zoom. This is what makes the "click
+// cluster → zoom in → it explodes into single pins" flow work (ADR-4).
 //
-// Algorithm: greedy single-pass grid-free agglomeration. O(n²) worst case, but
-// n is a single sub-map's point count (tens, not thousands) so this is fine for
-// the MVP. If a sub-map ever holds 100s of points we'd swap in a spatial grid
-// (noted in frontend-libraries.md performance checkpoints).
+// Algorithm: build a distance graph and return its connected components. O(n²)
+// worst case, but n is a single sub-map's point count (tens, not thousands) so
+// this is fine for the MVP. If a sub-map ever holds 100s of points we'd swap in
+// a spatial grid (noted in frontend-libraries.md performance checkpoints).
 //
-// All magic numbers live in CLUSTER_TUNING so Q6 ("initial 36px/scale, tune
+// All magic numbers live in CLUSTER_TUNING so Q6 ("initial 75px/scale, tune
 // after seeing it") is a one-line change.
 
 import type { PhotoDto } from "@/lib/photos";
 
 export const CLUSTER_TUNING = {
   /**
-   * Base merge distance in SCREEN pixels at scale 1. Two points whose
-   * on-screen centers are closer than `BASE_THRESHOLD_PX / scale` merge into a
-   * cluster. 36px ≈ comfortably larger than a 8-10px pin so visually touching
-   * pins group up (Q6 initial value).
+   * Base merge distance in image-surface pixels at scale 1. The effective
+   * surface threshold is `BASE_THRESHOLD_PX / scale²`: low zoom strongly groups
+   * close seat marks, while high zoom quickly separates them for clicking.
    */
-  BASE_THRESHOLD_PX: 36,
-  /** Below this scale, never cluster (points are spread enough). Keeps fully
-   *  zoomed-in views showing every individual pin even if data is dense. */
+  BASE_THRESHOLD_PX: 75,
+  /** Below this surface-pixel threshold, never shrink further. */
   MIN_THRESHOLD_PX: 2,
 } as const;
 
@@ -51,8 +49,8 @@ export interface Cluster {
 }
 
 /**
- * Compute the active screen-pixel merge threshold for a given zoom scale.
- * Inverse to scale (Q6), floored so it never reaches zero.
+ * Compute the first-stage merge threshold for a given zoom scale. `clusterPoints`
+ * divides this by scale again to compare image-surface distances.
  */
 export function clusterThresholdPx(scale: number): number {
   const safeScale = scale > 0 ? scale : 1;
@@ -80,61 +78,72 @@ export function layOutPoints(
 }
 
 /**
- * Greedy-agglomerate laid-out points into clusters at the given zoom scale.
+ * Group laid-out points into connected components at the given zoom scale.
  *
- * The merge distance is measured in SCREEN pixels, so we compare image-surface
- * distances against `threshold / scale` (image-space) — equivalently the
- * on-screen distance against `threshold`. A point joins the first existing
- * cluster whose centroid is within range; centroids are recomputed as members
- * are added so a cluster's anchor tracks its members.
+ * The merge distance is compared in image-surface pixels. Any chain of points
+ * where each adjacent pair is within threshold becomes one cluster, so a dense
+ * row cannot be split by centroid drift or input order.
  */
 export function clusterPoints(
   points: readonly LaidOutPoint[],
   scale: number,
 ): Cluster[] {
-  const thresholdScreenPx = clusterThresholdPx(scale);
-  // Convert the screen-pixel threshold to image-surface pixels: the surface is
-  // magnified by `scale`, so a fixed on-screen gap spans fewer surface pixels
-  // as you zoom in.
   const safeScale = scale > 0 ? scale : 1;
-  const thresholdSurfacePx = thresholdScreenPx / safeScale;
+  const thresholdSurfacePx = clusterThresholdPx(safeScale) / safeScale;
   const thresholdSq = thresholdSurfacePx * thresholdSurfacePx;
 
-  const clusters: Cluster[] = [];
+  const parent = points.map((_, index) => index);
+  const find = (index: number): number => {
+    const root = parent[index];
+    if (root === undefined) return index;
+    if (root === index) return index;
+    const next = find(root);
+    parent[index] = next;
+    return next;
+  };
+  const union = (a: number, b: number): void => {
+    const rootA = find(a);
+    const rootB = find(b);
+    if (rootA !== rootB) parent[rootB] = rootA;
+  };
 
-  for (const point of points) {
-    let merged = false;
-    for (const cluster of clusters) {
-      const dx = cluster.x - point.x;
-      const dy = cluster.y - point.y;
-      if (dx * dx + dy * dy <= thresholdSq) {
-        cluster.members.push(point);
-        // Recompute centroid incrementally.
-        const n = cluster.members.length;
-        cluster.x += (point.x - cluster.x) / n;
-        cluster.y += (point.y - cluster.y) / n;
-        merged = true;
-        break;
-      }
-    }
-    if (!merged) {
-      clusters.push({
-        id: point.photo.id,
-        x: point.x,
-        y: point.y,
-        members: [point],
-      });
+  for (let i = 0; i < points.length; i += 1) {
+    const a = points[i]!;
+    for (let j = i + 1; j < points.length; j += 1) {
+      const b = points[j]!;
+      const dx = a.x - b.x;
+      const dy = a.y - b.y;
+      if (dx * dx + dy * dy <= thresholdSq) union(i, j);
     }
   }
 
-  // Give multi-member clusters a distinct, stable id so React keys don't clash
-  // with the single-pin case (member[0].id is reused as the pin id).
-  for (const cluster of clusters) {
-    if (cluster.members.length > 1)
-      cluster.id = `cluster:${cluster.members[0]!.photo.id}`;
+  const groups = new Map<number, LaidOutPoint[]>();
+  for (let index = 0; index < points.length; index += 1) {
+    const root = find(index);
+    const group = groups.get(root);
+    if (group) {
+      group.push(points[index]!);
+    } else {
+      groups.set(root, [points[index]!]);
+    }
   }
 
-  return clusters;
+  return Array.from(groups.values())
+    .map((members) => {
+      members.sort((a, b) => a.photo.id.localeCompare(b.photo.id));
+      const x =
+        members.reduce((sum, member) => sum + member.x, 0) / members.length;
+      const y =
+        members.reduce((sum, member) => sum + member.y, 0) / members.length;
+      const first = members[0]!;
+      return {
+        id: members.length > 1 ? `cluster:${first.photo.id}` : first.photo.id,
+        x,
+        y,
+        members,
+      };
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
 }
 
 function clamp01(value: number): number {


### PR DESCRIPTION
## What does this PR do?

Fixes the seatmap marker clustering bug where only the first two nearby points were grouped and the rest remained as independent pins. The clustering algorithm now uses connected components, so any chain of nearby markers becomes one stable cluster regardless of input order.

This also tunes the low-zoom merge threshold for the Ariake Arena issue #51 data while keeping the existing behavior that higher zoom levels split clusters more aggressively.

Closes #51

## Type of change

- [ ] New venue (`data/venues/<venue-id>.json`)
- [ ] Edit to an existing venue
- [x] Site code / docs change
- [ ] Other (describe below)

## Venue checklist (fill in for venue PRs)

N/A - this is a site code bug fix.

## Notes for the maintainer

Approach:
- Replaced centroid-based greedy clustering with connected-components grouping.
- Increased `BASE_THRESHOLD_PX` from `36` to `75` while preserving the current effective `BASE_THRESHOLD_PX / scale²` surface threshold.
- Added regression coverage for transitive chains, input-order independence, separated groups, and zoom-driven split behavior.

Validation:
- `npm test`
- `npm run typecheck`
- `npm run format:check`
- `npm run build`

Manual data check against production Ariake Arena API on 2026-05-28:
- scale 1: largest cluster has 6 inner-arena markers
- scale 1.2: largest cluster has 5 inner-arena markers
- scale 1.7 / 2: only the closest pair remains clustered
- scale 3: all markers split into individual pins