### PR TITLE
fix(venue): preserve sidebar scroll position

### DIFF
--- a/src/islands/VenueTree.tsx
+++ b/src/islands/VenueTree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, Star } from "lucide-react";
 import type { Locale } from "@/i18n/config";
 import { getMessages, venueName } from "@/i18n";
@@ -20,6 +20,7 @@ interface VenueTreeProps {
 }
 
 const expandedKey = STORAGE_KEYS.treeExpanded;
+export const VENUE_TREE_READY_EVENT = "seatview:venue-tree-ready";
 
 /** Read the persisted set of expanded region/prefecture slugs. */
 function readExpanded(): Set<string> | null {
@@ -49,6 +50,7 @@ export default function VenueTree({
   activeVenueId,
   onSelect,
 }: VenueTreeProps) {
+  const readyDispatchedRef = useRef(false);
   const tree: RegionNode[] = useMemo(() => buildVenueTree(), []);
 
   // Every populated region + prefecture starts expanded (shape decision 3).
@@ -64,11 +66,19 @@ export default function VenueTree({
   // Start from the all-expanded default for a stable SSR/first paint, then
   // reconcile with any persisted choice after mount (avoids hydration drift).
   const [expanded, setExpanded] = useState<Set<string>>(allSlugs);
+  const [expandedReady, setExpandedReady] = useState(false);
 
   useEffect(() => {
     const persisted = readExpanded();
     if (persisted) setExpanded(persisted);
+    setExpandedReady(true);
   }, []);
+
+  useEffect(() => {
+    if (!expandedReady || readyDispatchedRef.current) return;
+    readyDispatchedRef.current = true;
+    window.dispatchEvent(new Event(VENUE_TREE_READY_EVENT));
+  }, [expanded, expandedReady]);
 
   const toggle = useCallback((slug: string) => {
     setExpanded((prev) => {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -14,6 +14,8 @@ export const STORAGE_KEYS = {
   locale: "seatview:locale",
   /** Venue-tree expanded region/prefecture slugs (session-scoped feel). */
   treeExpanded: "seatview:lang-tree-expanded",
+  /** Desktop venue-tree scroll offset, preserved across venue-page reloads. */
+  treeScrollTop: "seatview:venue-tree-scroll-top",
 } as const;
 
 /** SSR-safe localStorage read. Returns null on the server or on access error. */

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -198,10 +198,10 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
             }
           };
 
-          treeScroller.addEventListener("scroll", rememberTreeScroll, {
-            passive: true,
-          });
           window.addEventListener("pagehide", rememberTreeScroll);
+          document.addEventListener("visibilitychange", () => {
+            if (document.visibilityState === "hidden") rememberTreeScroll();
+          });
 
           if (treeReadyEvent) {
             window.addEventListener(

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -18,6 +18,7 @@ import { getMessages, venueName } from "@/i18n";
 import { getVenue } from "@/data/venues";
 import { getPrefecture, prefectureName } from "@/data/prefectures";
 import { readSubMapFromUrl, resolveInitialSubMapId } from "@/lib/submap";
+import { STORAGE_KEYS } from "@/lib/storage";
 import { env } from "cloudflare:workers";
 import { getDb } from "@/server/db";
 import { listSubMapPhotos } from "@/server/photos";
@@ -81,6 +82,8 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
         <div class="flex flex-1">
           {/* Desktop venue tree: 280px, always-on, independent scroll. */}
           <aside
+            data-venue-tree-scroll-container
+            data-scroll-storage-key={STORAGE_KEYS.treeScrollTop}
             class="border-border bg-card sticky top-14 hidden h-[calc(100vh-3.5rem)] w-[280px] shrink-0 overflow-y-auto border-r px-3 py-4 lg:block"
           >
             <VenueTree locale={locale} activeVenueId={venue.id} client:idle />
@@ -157,6 +160,48 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
           localStorage.setItem("seatview:last-venue", lastVenueId);
         } catch (_) {
           /* ignore privacy-mode errors */
+        }
+      </script>
+      <script is:inline>
+        const treeScroller = document.querySelector(
+          "[data-venue-tree-scroll-container]",
+        );
+
+        if (treeScroller instanceof HTMLElement) {
+          const treeScrollTopKey = treeScroller.dataset.scrollStorageKey;
+          const rememberTreeScroll = () => {
+            if (!treeScrollTopKey) return;
+            try {
+              localStorage.setItem(
+                treeScrollTopKey,
+                String(treeScroller.scrollTop),
+              );
+            } catch (_) {
+              /* ignore privacy-mode errors */
+            }
+          };
+
+          try {
+            const rawScrollTop = treeScrollTopKey
+              ? localStorage.getItem(treeScrollTopKey)
+              : null;
+            const scrollTop = rawScrollTop
+              ? Number.parseInt(rawScrollTop, 10)
+              : 0;
+
+            if (Number.isFinite(scrollTop) && scrollTop > 0) {
+              requestAnimationFrame(() => {
+                treeScroller.scrollTop = scrollTop;
+              });
+            }
+          } catch (_) {
+            /* ignore privacy-mode errors */
+          }
+
+          treeScroller.addEventListener("scroll", rememberTreeScroll, {
+            passive: true,
+          });
+          window.addEventListener("pagehide", rememberTreeScroll);
         }
       </script>
       </Fragment>

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -8,7 +8,7 @@
 import Layout from "@/layouts/Layout.astro";
 import SiteHeader from "@/components/SiteHeader.astro";
 import SiteFooter from "@/components/SiteFooter.astro";
-import VenueTree from "@/islands/VenueTree.tsx";
+import VenueTree, { VENUE_TREE_READY_EVENT } from "@/islands/VenueTree.tsx";
 import VenueTreeDrawer from "@/islands/VenueTreeDrawer.tsx";
 import VenueSearch from "@/islands/VenueSearch.tsx";
 import SubMapTabs from "@/islands/SubMapTabs.tsx";
@@ -83,6 +83,7 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
           {/* Desktop venue tree: 280px, always-on, independent scroll. */}
           <aside
             data-venue-tree-scroll-container
+            data-ready-event={VENUE_TREE_READY_EVENT}
             data-scroll-storage-key={STORAGE_KEYS.treeScrollTop}
             class="border-border bg-card sticky top-14 hidden h-[calc(100vh-3.5rem)] w-[280px] shrink-0 overflow-y-auto border-r px-3 py-4 lg:block"
           >
@@ -169,6 +170,7 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
 
         if (treeScroller instanceof HTMLElement) {
           const treeScrollTopKey = treeScroller.dataset.scrollStorageKey;
+          const treeReadyEvent = treeScroller.dataset.readyEvent;
           const rememberTreeScroll = () => {
             if (!treeScrollTopKey) return;
             try {
@@ -181,7 +183,7 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
             }
           };
 
-          try {
+          const restoreTreeScroll = () => {
             const rawScrollTop = treeScrollTopKey
               ? localStorage.getItem(treeScrollTopKey)
               : null;
@@ -194,14 +196,26 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
                 treeScroller.scrollTop = scrollTop;
               });
             }
-          } catch (_) {
-            /* ignore privacy-mode errors */
-          }
+          };
 
           treeScroller.addEventListener("scroll", rememberTreeScroll, {
             passive: true,
           });
           window.addEventListener("pagehide", rememberTreeScroll);
+
+          if (treeReadyEvent) {
+            window.addEventListener(
+              treeReadyEvent,
+              () => {
+                try {
+                  restoreTreeScroll();
+                } catch (_) {
+                  /* ignore privacy-mode errors */
+                }
+              },
+              { once: true },
+            );
+          }
         }
       </script>
       </Fragment>


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop venue tree jumping back to the top after switching venues. The venue page now stores the desktop sidebar scroll offset in the shared `seatview:*` storage namespace and restores it from the page shell before the idle React island hydration matters.

Closes #53

## Type of change

- [ ] New venue (`data/venues/<venue-id>.json`)
- [ ] Edit to an existing venue
- [x] Site code / docs change
- [ ] Other (describe below)

## Venue checklist (fill in for venue PRs)

- [ ] **Seating chart has no copyright risk.** Charts under `public/seatmaps/`
      are locally-authored placeholders or otherwise free of third-party
      copyright. I did NOT commit a real copyrighted seating chart.
- [ ] **All fields are complete.** `id`, `name_zh`, `name_jp`, `name_romaji`,
      `prefecture`, `city`, `aliases`, and at least one `subMaps[]` entry are
      present and match the `Venue` / `SubMap` types (see CONTRIBUTING.md).
- [ ] **`prefecture` uses a valid slug** from `src/data/prefectures.ts`
      (e.g. `tokyo`, `kanagawa`, `osaka`, `overseas`).
- [ ] **`id` is unique** across `data/venues/*.json` and is a url-safe slug
      (lowercase, hyphenated). The JSON filename equals `<id>.json`.
- [ ] **Each `subMaps[].imageUrl`** points at `public/seatmaps/<id>/<sub-map-id>.svg`
      (or another asset I committed), and `width` / `height` are the chart's
      actual pixel dimensions.
- [x] **The build passes locally**: `npm run build` succeeds and
      `npm run typecheck` reports no errors.

## Notes for the maintainer

Validated locally:

- `npm run format:check`
- `npm run typecheck`
- `npm test`
- `npm run build`
- Playwright manual check: scroll desktop sidebar to `420`, navigate from `/zh/v/k-arena-yokohama` to `/zh/v/tokyo-dome`, sidebar restores to `420`.
