### PR TITLE
fix(venue): restore mobile drawer scroll position

### DIFF
--- a/src/islands/VenueTree.tsx
+++ b/src/islands/VenueTree.tsx
@@ -17,6 +17,8 @@ interface VenueTreeProps {
    * the drawer after selection.
    */
   onSelect?: (venueId: string) => void;
+  /** Called once after persisted expand/collapse state has been applied. */
+  onReady?: () => void;
 }
 
 const expandedKey = STORAGE_KEYS.treeExpanded;
@@ -49,6 +51,7 @@ export default function VenueTree({
   locale,
   activeVenueId,
   onSelect,
+  onReady,
 }: VenueTreeProps) {
   const readyDispatchedRef = useRef(false);
   const tree: RegionNode[] = useMemo(() => buildVenueTree(), []);
@@ -78,7 +81,8 @@ export default function VenueTree({
     if (!expandedReady || readyDispatchedRef.current) return;
     readyDispatchedRef.current = true;
     window.dispatchEvent(new Event(VENUE_TREE_READY_EVENT));
-  }, [expanded, expandedReady]);
+    onReady?.();
+  }, [expanded, expandedReady, onReady]);
 
   const toggle = useCallback((slug: string) => {
     setExpanded((prev) => {

--- a/src/islands/VenueTreeDrawer.tsx
+++ b/src/islands/VenueTreeDrawer.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Menu, X } from "lucide-react";
 import type { Locale } from "@/i18n/config";
 import { useLocale } from "@/hooks/useLocale";
+import { STORAGE_KEYS, readStorage, writeStorage } from "@/lib/storage";
 import VenueTree from "./VenueTree";
 import { cn } from "@/lib/utils";
 
@@ -26,12 +27,68 @@ export default function VenueTreeDrawer({
   const { t } = useLocale(locale);
   const [open, setOpen] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const userScrolledRef = useRef(false);
+
+  const rememberScroll = useCallback(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+    writeStorage(STORAGE_KEYS.treeScrollTop, String(scroller.scrollTop));
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    userScrolledRef.current = true;
+    rememberScroll();
+  }, [rememberScroll]);
+
+  const restoreScroll = useCallback(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+
+    requestAnimationFrame(() => {
+      const rawScrollTop = readStorage(STORAGE_KEYS.treeScrollTop);
+      const scrollTop = rawScrollTop ? Number.parseInt(rawScrollTop, 10) : 0;
+
+      if (
+        userScrolledRef.current &&
+        Number.isFinite(scrollTop) &&
+        scrollTop > 0
+      ) {
+        scroller.scrollTop = scrollTop;
+        return;
+      }
+
+      const activeLink = activeVenueId
+        ? scroller.querySelector<HTMLElement>('a[aria-current="page"]')
+        : null;
+
+      if (activeLink) {
+        const scrollerRect = scroller.getBoundingClientRect();
+        const activeRect = activeLink.getBoundingClientRect();
+        const centeredTop =
+          activeRect.top -
+          scrollerRect.top +
+          scroller.scrollTop -
+          scroller.clientHeight / 2 +
+          activeLink.clientHeight / 2;
+
+        scroller.scrollTop = Math.max(0, centeredTop);
+        rememberScroll();
+        return;
+      }
+
+      if (Number.isFinite(scrollTop) && scrollTop > 0) {
+        scroller.scrollTop = scrollTop;
+      }
+    });
+  }, [activeVenueId, rememberScroll]);
 
   const close = useCallback(() => {
+    rememberScroll();
     setOpen(false);
     triggerRef.current?.focus();
-  }, []);
+  }, [rememberScroll]);
 
   // Esc to close + body scroll lock while open.
   useEffect(() => {
@@ -96,10 +153,15 @@ export default function VenueTreeDrawer({
                 <X className="size-4" aria-hidden="true" />
               </button>
             </div>
-            <div className="flex-1 overflow-y-auto px-2 py-3">
+            <div
+              ref={scrollerRef}
+              onScroll={handleScroll}
+              className="flex-1 overflow-y-auto px-2 py-3"
+            >
               <VenueTree
                 locale={locale}
                 activeVenueId={activeVenueId}
+                onReady={restoreScroll}
                 onSelect={() => close()}
               />
             </div>


### PR DESCRIPTION
## Summary
- Restore mobile/tablet venue drawer scroll after the tree finishes applying persisted expansion state.
- Prefer the current active venue row as the opening anchor, with persisted scrollTop as fallback.
- Keep desktop sidebar scroll behavior unchanged.

Fixes #53

## Verification
- npm run typecheck
- npm run format:check
- npm test
- Playwright mobile viewport 390x844: opened `/zh/v/yoyogi-national-gymnasium`, tapped the hamburger menu, and confirmed the active venue row is visible in the drawer instead of starting at the top.