### PR TITLE
fix(venue): center desktop tree selection before hydration

### DIFF
--- a/src/islands/VenueTree.tsx
+++ b/src/islands/VenueTree.tsx
@@ -131,6 +131,10 @@ export default function VenueTree({
                                   <a
                                     href={`/${locale}/v/${venue.id}`}
                                     aria-current={active ? "page" : undefined}
+                                    data-venue-tree-active-row={
+                                      active ? "true" : undefined
+                                    }
+                                    data-venue-tree-venue-id={venue.id}
                                     onClick={() => onSelect?.(venue.id)}
                                     className={cn(
                                       "flex items-center gap-1.5 rounded-sm py-1.5 pr-2 pl-2 text-sm",

--- a/src/islands/VenueTreeDrawer.tsx
+++ b/src/islands/VenueTreeDrawer.tsx
@@ -55,6 +55,25 @@ export default function VenueTreeDrawer({
     if (!scroller) return;
 
     restoringScrollRef.current = true;
+
+    // Tie the guard reset to whichever fires first: the programmatic scroll
+    // event from `scroller.scrollTop = X`, or a RAF fallback for the case
+    // where the assignment doesn't actually change the value (browser elides
+    // the event). Safari/under-load can deliver the scroll event AFTER a
+    // bare RAF callback, which would let `handleScroll` flip
+    // `userScrolledRef` even though the user never touched the drawer.
+    const finishRestoring = () => {
+      let done = false;
+      const clear = () => {
+        if (done) return;
+        done = true;
+        scroller.removeEventListener("scroll", clear);
+        restoringScrollRef.current = false;
+      };
+      scroller.addEventListener("scroll", clear, { once: true });
+      requestAnimationFrame(clear);
+    };
+
     const rawScrollTop = readStorage(STORAGE_KEYS.treeScrollTop);
     const scrollTop = rawScrollTop ? Number.parseInt(rawScrollTop, 10) : 0;
 
@@ -64,9 +83,7 @@ export default function VenueTreeDrawer({
       scrollTop > 0
     ) {
       scroller.scrollTop = scrollTop;
-      requestAnimationFrame(() => {
-        restoringScrollRef.current = false;
-      });
+      finishRestoring();
       return;
     }
 
@@ -90,9 +107,7 @@ export default function VenueTreeDrawer({
 
       scroller.scrollTop = Math.min(Math.max(0, centeredTop), maxScrollTop);
       rememberScroll();
-      requestAnimationFrame(() => {
-        restoringScrollRef.current = false;
-      });
+      finishRestoring();
       return;
     }
 
@@ -100,9 +115,7 @@ export default function VenueTreeDrawer({
       scroller.scrollTop = scrollTop;
     }
 
-    requestAnimationFrame(() => {
-      restoringScrollRef.current = false;
-    });
+    finishRestoring();
   }, [activeVenueId, rememberScroll]);
 
   useLayoutEffect(() => {

--- a/src/islands/VenueTreeDrawer.tsx
+++ b/src/islands/VenueTreeDrawer.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { Menu, X } from "lucide-react";
 import type { Locale } from "@/i18n/config";
 import { useLocale } from "@/hooks/useLocale";
@@ -29,6 +35,7 @@ export default function VenueTreeDrawer({
   const panelRef = useRef<HTMLDivElement>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const restoringScrollRef = useRef(false);
   const userScrolledRef = useRef(false);
 
   const rememberScroll = useCallback(() => {
@@ -38,6 +45,7 @@ export default function VenueTreeDrawer({
   }, []);
 
   const handleScroll = useCallback(() => {
+    if (restoringScrollRef.current) return;
     userScrolledRef.current = true;
     rememberScroll();
   }, [rememberScroll]);
@@ -46,43 +54,61 @@ export default function VenueTreeDrawer({
     const scroller = scrollerRef.current;
     if (!scroller) return;
 
+    restoringScrollRef.current = true;
+    const rawScrollTop = readStorage(STORAGE_KEYS.treeScrollTop);
+    const scrollTop = rawScrollTop ? Number.parseInt(rawScrollTop, 10) : 0;
+
+    if (
+      userScrolledRef.current &&
+      Number.isFinite(scrollTop) &&
+      scrollTop > 0
+    ) {
+      scroller.scrollTop = scrollTop;
+      requestAnimationFrame(() => {
+        restoringScrollRef.current = false;
+      });
+      return;
+    }
+
+    const activeLink = activeVenueId
+      ? scroller.querySelector<HTMLElement>("[data-venue-tree-active-row]")
+      : null;
+
+    if (activeLink) {
+      const scrollerRect = scroller.getBoundingClientRect();
+      const activeRect = activeLink.getBoundingClientRect();
+      const centeredTop =
+        activeRect.top -
+        scrollerRect.top +
+        scroller.scrollTop -
+        scroller.clientHeight / 2 +
+        activeLink.clientHeight / 2;
+      const maxScrollTop = Math.max(
+        0,
+        scroller.scrollHeight - scroller.clientHeight,
+      );
+
+      scroller.scrollTop = Math.min(Math.max(0, centeredTop), maxScrollTop);
+      rememberScroll();
+      requestAnimationFrame(() => {
+        restoringScrollRef.current = false;
+      });
+      return;
+    }
+
+    if (Number.isFinite(scrollTop) && scrollTop > 0) {
+      scroller.scrollTop = scrollTop;
+    }
+
     requestAnimationFrame(() => {
-      const rawScrollTop = readStorage(STORAGE_KEYS.treeScrollTop);
-      const scrollTop = rawScrollTop ? Number.parseInt(rawScrollTop, 10) : 0;
-
-      if (
-        userScrolledRef.current &&
-        Number.isFinite(scrollTop) &&
-        scrollTop > 0
-      ) {
-        scroller.scrollTop = scrollTop;
-        return;
-      }
-
-      const activeLink = activeVenueId
-        ? scroller.querySelector<HTMLElement>('a[aria-current="page"]')
-        : null;
-
-      if (activeLink) {
-        const scrollerRect = scroller.getBoundingClientRect();
-        const activeRect = activeLink.getBoundingClientRect();
-        const centeredTop =
-          activeRect.top -
-          scrollerRect.top +
-          scroller.scrollTop -
-          scroller.clientHeight / 2 +
-          activeLink.clientHeight / 2;
-
-        scroller.scrollTop = Math.max(0, centeredTop);
-        rememberScroll();
-        return;
-      }
-
-      if (Number.isFinite(scrollTop) && scrollTop > 0) {
-        scroller.scrollTop = scrollTop;
-      }
+      restoringScrollRef.current = false;
     });
   }, [activeVenueId, rememberScroll]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    restoreScroll();
+  }, [open, restoreScroll]);
 
   const close = useCallback(() => {
     rememberScroll();

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -16,6 +16,8 @@ export const STORAGE_KEYS = {
   treeExpanded: "seatview:lang-tree-expanded",
   /** Desktop venue-tree scroll offset, preserved across venue-page reloads. */
   treeScrollTop: "seatview:venue-tree-scroll-top",
+  /** Venue id picked from the desktop tree, used to center the next page early. */
+  treePendingVenue: "seatview:venue-tree-pending-venue",
 } as const;
 
 /** SSR-safe localStorage read. Returns null on the server or on access error. */

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -83,7 +83,9 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
           {/* Desktop venue tree: 280px, always-on, independent scroll. */}
           <aside
             data-venue-tree-scroll-container
+            data-active-venue-id={venue.id}
             data-ready-event={VENUE_TREE_READY_EVENT}
+            data-pending-venue-key={STORAGE_KEYS.treePendingVenue}
             data-scroll-storage-key={STORAGE_KEYS.treeScrollTop}
             class="border-border bg-card sticky top-14 hidden h-[calc(100vh-3.5rem)] w-[280px] shrink-0 overflow-y-auto border-r px-3 py-4 lg:block"
           >
@@ -97,6 +99,142 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
               </a>
             </div>
           </aside>
+          <script is:inline>
+            const treeScroller = document.querySelector(
+              "[data-venue-tree-scroll-container]",
+            );
+
+            if (treeScroller instanceof HTMLElement) {
+              const activeVenueId = treeScroller.dataset.activeVenueId;
+              const pendingVenueKey = treeScroller.dataset.pendingVenueKey;
+              const treeScrollTopKey = treeScroller.dataset.scrollStorageKey;
+              const treeReadyEvent = treeScroller.dataset.readyEvent;
+
+              const readTreeScrollTop = () => {
+                if (!treeScrollTopKey) return null;
+                try {
+                  const rawScrollTop = localStorage.getItem(treeScrollTopKey);
+                  const scrollTop = rawScrollTop
+                    ? Number.parseInt(rawScrollTop, 10)
+                    : 0;
+                  return Number.isFinite(scrollTop)
+                    ? Math.max(0, scrollTop)
+                    : null;
+                } catch (_) {
+                  return null;
+                }
+              };
+
+              const rememberTreeScroll = () => {
+                if (!treeScrollTopKey) return;
+                try {
+                  localStorage.setItem(
+                    treeScrollTopKey,
+                    String(treeScroller.scrollTop),
+                  );
+                } catch (_) {
+                  /* ignore privacy-mode errors */
+                }
+              };
+
+              const centerActiveVenue = () => {
+                const activeLink = treeScroller.querySelector(
+                  "[data-venue-tree-active-row]",
+                );
+                if (!(activeLink instanceof HTMLElement)) return false;
+
+                const scrollerRect = treeScroller.getBoundingClientRect();
+                const activeRect = activeLink.getBoundingClientRect();
+                const centeredTop =
+                  activeRect.top -
+                  scrollerRect.top +
+                  treeScroller.scrollTop -
+                  treeScroller.clientHeight / 2 +
+                  activeLink.clientHeight / 2;
+                const maxScrollTop = Math.max(
+                  0,
+                  treeScroller.scrollHeight - treeScroller.clientHeight,
+                );
+
+                treeScroller.scrollTop = Math.min(
+                  Math.max(0, centeredTop),
+                  maxScrollTop,
+                );
+                return true;
+              };
+
+              const consumePendingVenueMatch = () => {
+                if (!pendingVenueKey || !activeVenueId) return false;
+                try {
+                  const pendingVenueId = localStorage.getItem(pendingVenueKey);
+                  if (pendingVenueId) localStorage.removeItem(pendingVenueKey);
+                  return pendingVenueId === activeVenueId;
+                } catch (_) {
+                  return false;
+                }
+              };
+
+              const restoreTreeScroll = (preferActiveVenue) => {
+                if (preferActiveVenue && centerActiveVenue()) {
+                  rememberTreeScroll();
+                  return;
+                }
+
+                const scrollTop = readTreeScrollTop();
+                if (scrollTop && scrollTop > 0) {
+                  treeScroller.scrollTop = scrollTop;
+                  return;
+                }
+
+                if (centerActiveVenue()) rememberTreeScroll();
+              };
+
+              const preferActiveVenue = consumePendingVenueMatch();
+              restoreTreeScroll(preferActiveVenue);
+              requestAnimationFrame(() => restoreTreeScroll(preferActiveVenue));
+
+              treeScroller.addEventListener(
+                "click",
+                (event) => {
+                  if (!pendingVenueKey) return;
+                  const target =
+                    event.target instanceof Element ? event.target : null;
+                  const link = target?.closest("[data-venue-tree-venue-id]");
+                  if (!(link instanceof HTMLElement)) return;
+
+                  const nextVenueId = link.dataset.venueTreeVenueId;
+                  if (!nextVenueId) return;
+                  try {
+                    localStorage.setItem(pendingVenueKey, nextVenueId);
+                  } catch (_) {
+                    /* ignore privacy-mode errors */
+                  }
+                  rememberTreeScroll();
+                },
+                { capture: true },
+              );
+
+              window.addEventListener("pagehide", rememberTreeScroll);
+              document.addEventListener("visibilitychange", () => {
+                if (document.visibilityState === "hidden")
+                  rememberTreeScroll();
+              });
+
+              if (treeReadyEvent) {
+                window.addEventListener(
+                  treeReadyEvent,
+                  () => {
+                    try {
+                      restoreTreeScroll(preferActiveVenue);
+                    } catch (_) {
+                      /* ignore layout/storage errors */
+                    }
+                  },
+                  { once: true },
+                );
+              }
+            }
+          </script>
 
           {/* Main column: breadcrumb → title → tabs → seatmap → upload → grid. */}
           <main class="min-w-0 flex-1">
@@ -161,61 +299,6 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
           localStorage.setItem("seatview:last-venue", lastVenueId);
         } catch (_) {
           /* ignore privacy-mode errors */
-        }
-      </script>
-      <script is:inline>
-        const treeScroller = document.querySelector(
-          "[data-venue-tree-scroll-container]",
-        );
-
-        if (treeScroller instanceof HTMLElement) {
-          const treeScrollTopKey = treeScroller.dataset.scrollStorageKey;
-          const treeReadyEvent = treeScroller.dataset.readyEvent;
-          const rememberTreeScroll = () => {
-            if (!treeScrollTopKey) return;
-            try {
-              localStorage.setItem(
-                treeScrollTopKey,
-                String(treeScroller.scrollTop),
-              );
-            } catch (_) {
-              /* ignore privacy-mode errors */
-            }
-          };
-
-          const restoreTreeScroll = () => {
-            const rawScrollTop = treeScrollTopKey
-              ? localStorage.getItem(treeScrollTopKey)
-              : null;
-            const scrollTop = rawScrollTop
-              ? Number.parseInt(rawScrollTop, 10)
-              : 0;
-
-            if (Number.isFinite(scrollTop) && scrollTop > 0) {
-              requestAnimationFrame(() => {
-                treeScroller.scrollTop = scrollTop;
-              });
-            }
-          };
-
-          window.addEventListener("pagehide", rememberTreeScroll);
-          document.addEventListener("visibilitychange", () => {
-            if (document.visibilityState === "hidden") rememberTreeScroll();
-          });
-
-          if (treeReadyEvent) {
-            window.addEventListener(
-              treeReadyEvent,
-              () => {
-                try {
-                  restoreTreeScroll();
-                } catch (_) {
-                  /* ignore privacy-mode errors */
-                }
-              },
-              { once: true },
-            );
-          }
         }
       </script>
       </Fragment>

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -181,7 +181,7 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
                 }
 
                 const scrollTop = readTreeScrollTop();
-                if (scrollTop && scrollTop > 0) {
+                if (scrollTop !== null) {
                   treeScroller.scrollTop = scrollTop;
                   return;
                 }
@@ -191,7 +191,6 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
 
               const preferActiveVenue = consumePendingVenueMatch();
               restoreTreeScroll(preferActiveVenue);
-              requestAnimationFrame(() => restoreTreeScroll(preferActiveVenue));
 
               treeScroller.addEventListener(
                 "click",


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop venue-tree scroll jump when navigating from a lower sidebar venue. The next venue page now positions the desktop tree around the selected venue before React idle hydration, instead of briefly painting at the top and jumping later.

## Type of change

- [ ] New venue (`data/venues/<venue-id>.json`)
- [ ] Edit to an existing venue
- [x] Site code / docs change
- [ ] Other (describe below)

## Venue checklist (fill in for venue PRs)

- [ ] **Seating chart has no copyright risk.** Charts under `public/seatmaps/`
      are locally-authored placeholders or otherwise free of third-party
      copyright. I did NOT commit a real copyrighted seating chart.
- [ ] **All fields are complete.** `id`, `name_zh`, `name_jp`, `name_romaji`,
      `prefecture`, `city`, `aliases`, and at least one `subMaps[]` entry are
      present and match the `Venue` / `SubMap` types (see CONTRIBUTING.md).
- [ ] **`prefecture` uses a valid slug** from `src/data/prefectures.ts`
      (e.g. `tokyo`, `kanagawa`, `osaka`, `overseas`).
- [ ] **`id` is unique** across `data/venues/*.json` and is a url-safe slug
      (lowercase, hyphenated). The JSON filename equals `<id>.json`.
- [ ] **Each `subMaps[].imageUrl`** points at `public/seatmaps/<id>/<sub-map-id>.svg`
      (or another asset I committed), and `width` / `height` are the chart's
      actual pixel dimensions.
- [x] **The build passes locally**: `npm run build` succeeds and
      `npm run typecheck` reports no errors.

## Notes for the maintainer

- Adds server-rendered data markers to venue-tree links so the page shell can find the active row before hydration.
- Stores a short-lived pending venue id on desktop tree clicks, then consumes it on the next page to prefer centering the active row over replaying the previous `scrollTop`.
- Keeps persisted `scrollTop` as the fallback for reload/back-forward behavior.

Validation:
- `npm run typecheck`
- `npm test`
- `npm run build`
- Playwright desktop check: navigating from `爱知县艺术剧场` to lower-row `Marine Messe 福冈` had `scrollTop=1050` on the first sampled animation frame, before `seatview:venue-tree-ready`.

Co-Authored-By: Warp <agent@warp.dev>
