### PR TITLE
增加后台暂存区排序

### DIFF
--- a/src/islands/AdminConsole.tsx
+++ b/src/islands/AdminConsole.tsx
@@ -513,7 +513,7 @@ function StagingPanel({ locale }: { locale: Locale }) {
           const ids = new Set(prev.map((v) => v.id));
           const merged = [...prev];
           for (const v of next) if (!ids.has(v.id)) merged.push(v);
-          return merged;
+          return sortAdminStagingVenues(merged);
         });
         setLoaded(true);
         loadingRef.current = false;
@@ -532,7 +532,9 @@ function StagingPanel({ locale }: { locale: Locale }) {
 
   const onProcessedChange = useCallback((id: string, processed: boolean) => {
     setVenues((prev) =>
-      prev.map((v) => (v.id === id ? { ...v, processed } : v)),
+      sortAdminStagingVenues(
+        prev.map((v) => (v.id === id ? { ...v, processed } : v)),
+      ),
     );
   }, []);
   const onDeleted = useCallback(
@@ -599,6 +601,15 @@ function StagingPanel({ locale }: { locale: Locale }) {
       ) : null}
     </section>
   );
+}
+
+function sortAdminStagingVenues(
+  venues: readonly StagingVenueDto[],
+): StagingVenueDto[] {
+  return [...venues].sort((a, b) => {
+    if (a.processed !== b.processed) return a.processed ? 1 : -1;
+    return b.createdAt - a.createdAt;
+  });
 }
 
 function StagingAdminRow({

--- a/src/pages/api/admin/staging.ts
+++ b/src/pages/api/admin/staging.ts
@@ -1,10 +1,9 @@
 // /api/admin/staging — maintainer staging-area triage (R7.2). ALL methods sit
 // behind the Cloudflare Access edge gate (ADR-11) + the middleware admin guard.
 //
-// GET     list staging suggestions most-seconded-first (vote_count desc, paged;
-//         reuses the SAME listStagingVenues read as the public page — handy for
-//         triage: the most-demanded venues to promote surface at the top). It
-//         already exposes the `processed` flag (and now the `voteCount`).
+// GET     list staging suggestions for maintainer triage (unprocessed first,
+//         then processed, each group newest-first; issue #48). It already
+//         exposes the `processed` flag (and the `voteCount`).
 // PATCH   mark a suggestion processed / unprocessed (R7.2 "标记已处理"). The
 //         actual "转正式" promotion is a GitHub PR, NOT a backend action (R7.3).
 // DELETE  remove a suggestion outright (R7.2 "删除已处理的提交"). Staging rows
@@ -60,7 +59,11 @@ export const GET: APIRoute = async ({ request, url }) => {
 
   try {
     const db = getDb(env.DB);
-    const rows = await listStagingVenues(db, { offset, limit: limit + 1 });
+    const rows = await listStagingVenues(db, {
+      offset,
+      limit: limit + 1,
+      sort: "adminTriage",
+    });
     const hasMore = rows.length > limit;
     const payload: AdminStagingResponse = {
       venues: hasMore ? rows.slice(0, limit) : rows,

--- a/src/server/staging.ts
+++ b/src/server/staging.ts
@@ -291,9 +291,10 @@ export async function addVote(
 }
 
 // ── Maintainer admin (R7.2) ─────────────────────────────────────────────────
-// Behind the Cloudflare Access gate (ADR-11). The admin staging list reuses the
-// SAME `listStagingVenues` read above (it already exposes `processed`); the only
-// extra operations are the two mutations below: mark processed / unprocessed
+// Behind the Cloudflare Access gate (ADR-11). The admin staging list reuses
+// `listStagingVenues` (which exposes `processed`) but with the `adminTriage`
+// sort (unprocessed-first, newest-first; issue #48); the only extra
+// operations are the two mutations below: mark processed / unprocessed
 // (R7.2 "标记已处理") and delete a suggestion (R7.2 "删除已处理的提交"). The
 // "转正式" promotion itself happens via GitHub PR, NOT here (R7.3) — the schema
 // only tracks the `processed_at` triage flag.

--- a/src/server/staging.ts
+++ b/src/server/staging.ts
@@ -52,14 +52,21 @@ export interface ListStagingOptions {
    * Filtering in the query keeps offset paging self-consistent.
    */
   excludeProcessed?: boolean;
+  /**
+   * Public wishlist defaults to demand sorting. Admin triage can request
+   * unprocessed-first, newest-first ordering (issue #48).
+   */
+  sort?: "demand" | "adminTriage";
 }
 
 /** Default page size for the staging list (text-only rows are light, §11). */
 export const STAGING_BATCH = 50;
 
 /**
- * List staging-area suggestions, **most-seconded first** (`vote_count DESC`,
- * then `created_at DESC` as tiebreak — demand-strength signal for maintainers).
+ * List staging-area suggestions. Public views default to **most-seconded first**
+ * (`vote_count DESC`, then `created_at DESC`) as a demand-strength signal.
+ * Admin triage can request issue #48 ordering: unprocessed rows first, then
+ * processed rows, with each group newest-first.
  * Strips `ip_hash` and maps `processed_at` → a boolean `processed` flag. When
  * `viewerIpHash` is given, marks each row's `votedByMe` so the client can disable
  * the +1 button on venues this viewer already seconded.
@@ -68,13 +75,23 @@ export async function listStagingVenues(
   db: Db,
   options: ListStagingOptions = {},
 ): Promise<StagingVenueDto[]> {
+  const orderBy =
+    options.sort === "adminTriage"
+      ? [
+          // SQLite sorts false (0) before true (1), so unprocessed rows
+          // (`processed_at IS NOT NULL` = false) come first.
+          sql`${stagingVenues.processedAt} IS NOT NULL`,
+          desc(stagingVenues.createdAt),
+        ]
+      : [desc(stagingVenues.voteCount), desc(stagingVenues.createdAt)];
+
   const rows = await db
     .select()
     .from(stagingVenues)
     .where(
       options.excludeProcessed ? isNull(stagingVenues.processedAt) : undefined,
     )
-    .orderBy(desc(stagingVenues.voteCount), desc(stagingVenues.createdAt))
+    .orderBy(...orderBy)
     .limit(options.limit ?? STAGING_BATCH)
     .offset(options.offset ?? 0);
 


### PR DESCRIPTION
## 概要

Fixes #48

修正后台管理页面「暂存区」的排序规则：

- 未收录的场馆排在已收录场馆前面
- 同一组内按提交时间倒序排列，新提交的场馆在前面
- 公开暂存区列表仍保持原有按附议数排序的逻辑

## 实现

- 为 `listStagingVenues` 增加后台专用排序模式 `adminTriage`
- `/api/admin/staging` 使用后台排序模式
- 后台页面本地切换收录状态后，同步按相同规则更新当前列表顺序

