### PR TITLE
docs: README 新增致谢章节

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -225,3 +225,8 @@ There are two channels for adding new venues:
 
 > [!IMPORTANT]
 > The site code is open-sourced under **Apache 2.0** (see [LICENSE](LICENSE)). Photos uploaded by users and their metadata are shared under **[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/)** — there's a mandatory consent checkbox before uploading. **Do not submit copyrighted official seating charts**: everything under `public/seatmaps/` is uploaded by the maintainer (not official copyrighted images).
+
+## Acknowledgments
+
+- **Tech community** — thanks to the [Linux Do](https://linux.do/) community for the discussions and help during development.
+- **Seating-chart references** — venue seating charts were proofread with reference to [LiveKiti](https://livekiti.com/) and [LiveWalker](https://www.livewalker.com/).

--- a/README.ja.md
+++ b/README.ja.md
@@ -225,3 +225,8 @@ seatmap-real/
 
 > [!IMPORTANT]
 > サイトのコードは **Apache 2.0** でオープンソース化されています（[LICENSE](LICENSE) 参照）。ユーザーがアップロードした写真とそのメタデータは **[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/)** で共有されます——アップロード前に必須の同意チェックボックスがあります。**著作権のある公式座席表は提出しないでください**：`public/seatmaps/` 以下はすべてメンテナーがアップロードした座席表です（公式の著作権画像ではありません）。
+
+## 謝辞
+
+- **技術コミュニティ** —— 開発中の交流と協力をいただいた [Linux Do](https://linux.do/) コミュニティに感謝します。
+- **座席表の参考元** —— 会場の座席表は [LiveKiti](https://livekiti.com/) と [LiveWalker](https://www.livewalker.com/) を参考に校正しました。

--- a/README.ko.md
+++ b/README.ko.md
@@ -225,3 +225,8 @@ seatmap-real/
 
 > [!IMPORTANT]
 > 사이트 코드는 **Apache 2.0** 으로 오픈 소스화되어 있습니다([LICENSE](LICENSE) 참조). 사용자가 업로드한 사진과 그 메타데이터는 **[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/)** 으로 공유됩니다 —— 업로드 전에 필수 동의 체크박스가 있습니다. **저작권이 있는 공식 좌석도를 제출하지 마세요**: `public/seatmaps/` 아래는 전부 메인테이너가 업로드한 좌석도입니다(공식 저작권 이미지가 아님).
+
+## 감사의 말
+
+- **기술 커뮤니티** —— 개발 과정에서 교류와 도움을 준 [Linux Do](https://linux.do/) 커뮤니티에 감사드립니다.
+- **좌석도 참고 출처** —— 공연장 좌석도는 [LiveKiti](https://livekiti.com/) 와 [LiveWalker](https://www.livewalker.com/) 를 참고하여 교정했습니다.

--- a/README.md
+++ b/README.md
@@ -225,3 +225,8 @@ seatmap-real/
 
 > [!IMPORTANT]
 > 站点代码以 **Apache 2.0** 开源（见 [LICENSE](LICENSE)）。用户上传的照片及其元数据以 **[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/)** 共享——上传前有强制勾选的同意框。**请勿提交有版权的官方坐席图**：`public/seatmaps/` 下均为维护者上传的坐席图（非官方版权图）。
+
+## 致谢
+
+- **技术社区** —— 感谢 [Linux Do](https://linux.do/) 社区在开发过程中的交流与帮助。
+- **坐席图参考来源** —— 场馆坐席图的校对参考了 [LiveKiti](https://livekiti.com/) 与 [LiveWalker](https://www.livewalker.com/)。


### PR DESCRIPTION
## Summary
- 在 4 个语言版本 README（简/英/日/韩）末尾新增「致谢」章节
- 致谢 [Linux Do](https://linux.do/) 技术社区
- 标注坐席图参考来源 [LiveKiti](https://livekiti.com/) 与 [LiveWalker](https://www.livewalker.com/)

## Notes
- 纯文档改动，仅追加段落，未触动 i18n 切换条标记或其他内容
- 项目 Prettier 不覆盖 `.md`，无格式校验影响

## Test plan
- [ ] 确认 4 个 README 致谢章节渲染正常、链接可点击