### PR TITLE
Fix seatmap wheel zoom step

### DIFF
--- a/src/islands/Seatmap.tsx
+++ b/src/islands/Seatmap.tsx
@@ -34,6 +34,9 @@ import LoadFailure from "@/components/LoadFailure";
 
 const MIN_SCALE = 1;
 const MAX_SCALE = 6;
+// react-zoom-pan-pinch v4 removed v3's separate wheel.smoothStep; 0.001 keeps
+// one mouse-wheel notch near the old gradual zoom while leaving buttons intact.
+const WHEEL_ZOOM_STEP = 0.001;
 const FRAME_FALLBACK_WIDTH = 1.5;
 const FRAME_FALLBACK_HEIGHT = 1;
 /** Zoom multiplier applied when a cluster is clicked (shape §7: ×2). */
@@ -218,7 +221,7 @@ export default function Seatmap({
           centerOnInit
           limitToBounds
           doubleClick={{ disabled: true }}
-          wheel={{ step: 0.15 }}
+          wheel={{ step: WHEEL_ZOOM_STEP }}
           panning={{ velocityDisabled: reducedMotion }}
           onTransform={(_ref, state) => setScale(state.scale)}
           onPanningStart={() => {

--- a/src/islands/upload/MarkSurface.tsx
+++ b/src/islands/upload/MarkSurface.tsx
@@ -30,6 +30,9 @@ import { cn } from "@/lib/utils";
 
 const MIN_SCALE = 1;
 const MAX_SCALE = 6;
+// react-zoom-pan-pinch v4 removed v3's separate wheel.smoothStep; 0.001 keeps
+// one mouse-wheel notch near the old gradual zoom while leaving buttons intact.
+const WHEEL_ZOOM_STEP = 0.001;
 const ZOOM_ANIM_MS = 250;
 
 export interface AnnotationPoint {
@@ -173,7 +176,7 @@ export default function MarkSurface({
         centerOnInit
         limitToBounds
         doubleClick={{ disabled: true }}
-        wheel={{ step: 0.15 }}
+        wheel={{ step: WHEEL_ZOOM_STEP }}
         panning={{ velocityDisabled: reducedMotion }}
         onTransform={(_ref, state) => setScale(state.scale)}
       >


### PR DESCRIPTION
## Summary
- Restore gradual mouse-wheel zoom on the seatmap after the react-zoom-pan-pinch v4 upgrade.
- Apply the same wheel-step fix to the upload annotation surface.

## Verification
- npm run typecheck
- npm test
- npm run build
- In-app browser: wheel over [data-seatmap] moved 1.00x -> 1.12x -> 1.24x, then back to 1.12x.