### PR TITLE
fix: clarify seat label privacy placeholder

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -117,7 +117,7 @@ const en: Messages = {
     step3: {
       title: "3. Details",
       seatLabel: "Seat number",
-      seatPlaceholder: "e.g. 1F E-23",
+      seatPlaceholder: "e.g. 1F E 20-25 (for privacy)",
       seatRequired: "Seat number is required.",
       performanceDate: "Performance date (optional)",
       datePlaceholder: "YYYY-MM-DD",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -112,7 +112,7 @@ const ja: Messages = {
     step3: {
       title: "3. 詳細",
       seatLabel: "座席番号",
-      seatPlaceholder: "例: 1F E-23",
+      seatPlaceholder: "例: 1F E 20〜25番（プライバシー保護）",
       seatRequired: "座席番号を入力してください。",
       performanceDate: "公演日 任意",
       datePlaceholder: "YYYY-MM-DD",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -116,7 +116,7 @@ const ko: Messages = {
     step3: {
       title: "3. 세부 정보",
       seatLabel: "좌석 번호",
-      seatPlaceholder: "예: 1F E-23",
+      seatPlaceholder: "예: 1F E 20~25번 (개인정보 보호)",
       seatRequired: "좌석 번호는 필수예요.",
       performanceDate: "공연 날짜 선택",
       datePlaceholder: "YYYY-MM-DD",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -557,7 +557,7 @@ const zh: Messages = {
     step3: {
       title: "3. 元数据",
       seatLabel: "座位号",
-      seatPlaceholder: "例: 1F E-23",
+      seatPlaceholder: "例: 1F E 20~25号（保护账号隐私）",
       seatRequired: "座位号是必填的。",
       performanceDate: "演出日期 任意",
       datePlaceholder: "YYYY-MM-DD",


### PR DESCRIPTION
## Summary
- Update upload seat-number placeholders to suggest range-style fuzzy labels
- Keep copy localized across zh, ja, en, and ko

## Tests
- npm run typecheck