### PR TITLE
feat(venue): venue comments (giscus) + anonymous 5-star ratings

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,3 +17,13 @@ PUBLIC_SITE_URL=http://localhost:4321
 # Empty → uploaded images fall back to same-origin /r2/<key> (no public R2 domain
 # locally; see src/lib/photos.ts imageKeyToUrl).
 PUBLIC_R2_BASE_URL=
+
+# giscus venue comments (task 06-10-giscus). Non-secret resource identifiers.
+# All four are real: the maintainer created the "Venue Comments" Announcements
+# category + installed the giscus App, and the categoryId was confirmed via
+# GraphQL. Setup record:
+# .trellis/tasks/06-10-giscus/research/giscus-setup-steps.md.
+PUBLIC_GISCUS_REPO=Sallyn0225/seatview
+PUBLIC_GISCUS_REPO_ID=R_kgDOSmjr3g
+PUBLIC_GISCUS_CATEGORY=Venue Comments
+PUBLIC_GISCUS_CATEGORY_ID=DIC_kwDOSmjr3s4C-6z6

--- a/.env.production
+++ b/.env.production
@@ -14,3 +14,13 @@ PUBLIC_SITE_URL=https://seat.genchi.top
 # Public-read base URL for uploaded R2 images (custom domain). image_key is
 # appended to build the fetchable URL (src/lib/photos.ts).
 PUBLIC_R2_BASE_URL=https://img.genchi.top
+
+# giscus venue comments (task 06-10-giscus). Non-secret resource identifiers.
+# All four are real: the maintainer created the "Venue Comments" Announcements
+# category + installed the giscus App, and the categoryId was confirmed via
+# GraphQL. Setup record:
+# .trellis/tasks/06-10-giscus/research/giscus-setup-steps.md.
+PUBLIC_GISCUS_REPO=Sallyn0225/seatview
+PUBLIC_GISCUS_REPO_ID=R_kgDOSmjr3g
+PUBLIC_GISCUS_CATEGORY=Venue Comments
+PUBLIC_GISCUS_CATEGORY_ID=DIC_kwDOSmjr3s4C-6z6

--- a/giscus.json
+++ b/giscus.json
@@ -1,0 +1,9 @@
+{
+  "origins": [
+    "https://seat.genchi.top",
+    "http://localhost:4321",
+    "http://127.0.0.1:4321",
+    "http://localhost:8787",
+    "http://127.0.0.1:8787"
+  ]
+}

--- a/migrations/0005_venue_ratings.sql
+++ b/migrations/0005_venue_ratings.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `venue_rating_agg` (
+	`venue_id` text PRIMARY KEY NOT NULL,
+	`rating_count` integer DEFAULT 0 NOT NULL,
+	`rating_sum` integer DEFAULT 0 NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `venue_ratings` (
+	`id` text PRIMARY KEY NOT NULL,
+	`venue_id` text NOT NULL,
+	`score` integer NOT NULL,
+	`ip_hash` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_venue_ratings_dedup` ON `venue_ratings` (`venue_id`,`ip_hash`);

--- a/migrations/meta/0005_snapshot.json
+++ b/migrations/meta/0005_snapshot.json
@@ -1,0 +1,448 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6508f23a-6438-49b1-9c49-4b9b6b7a69a4",
+  "prevId": "8a9475c2-becd-41ea-8cc0-43acb1500349",
+  "tables": {
+    "photo_correction_requests": {
+      "name": "photo_correction_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "photo_id": {
+          "name": "photo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_seat_label": {
+          "name": "current_seat_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_seat_label": {
+          "name": "requested_seat_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_dedup_key": {
+          "name": "active_dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_photo_corrections_active_dedup": {
+          "name": "idx_photo_corrections_active_dedup",
+          "columns": [
+            "active_dedup_key"
+          ],
+          "isUnique": true
+        },
+        "idx_photo_corrections_pending": {
+          "name": "idx_photo_corrections_pending",
+          "columns": [
+            "processed_at",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_photo_corrections_photo": {
+          "name": "idx_photo_corrections_photo",
+          "columns": [
+            "photo_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "photos": {
+      "name": "photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sub_map_id": {
+          "name": "sub_map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "x_percent": {
+          "name": "x_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "y_percent": {
+          "name": "y_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seat_label": {
+          "name": "seat_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performance_date": {
+          "name": "performance_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_photos_venue": {
+          "name": "idx_photos_venue",
+          "columns": [
+            "venue_id",
+            "sub_map_id",
+            "deleted_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staging_venues": {
+      "name": "staging_venues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staging_votes": {
+      "name": "staging_votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_staging_votes_unique": {
+          "name": "idx_staging_votes_unique",
+          "columns": [
+            "venue_id",
+            "ip_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_staging_votes_ip": {
+          "name": "idx_staging_votes_ip",
+          "columns": [
+            "ip_hash",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "venue_rating_agg": {
+      "name": "venue_rating_agg",
+      "columns": {
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_count": {
+          "name": "rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rating_sum": {
+          "name": "rating_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "venue_ratings": {
+      "name": "venue_ratings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_venue_ratings_dedup": {
+          "name": "idx_venue_ratings_dedup",
+          "columns": [
+            "venue_id",
+            "ip_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1780483734454,
       "tag": "0004_steep_daimon_hellstrom",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1781133934814,
+      "tag": "0005_venue_ratings",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@astrojs/cloudflare": "^13.6.1",
         "@astrojs/react": "^5.0.7",
+        "@giscus/react": "^3.1.0",
         "astro": "^6.4.4",
         "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
@@ -2258,6 +2259,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@giscus/react": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/@giscus/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==",
+      "dependencies": {
+        "giscus": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18 || ^19",
+        "react-dom": "^16 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/@img/colour/-/colour-1.1.0.tgz",
@@ -2766,6 +2779,21 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3689,6 +3717,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -5501,6 +5535,15 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/giscus": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/giscus/-/giscus-1.6.0.tgz",
+      "integrity": "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lit": "^3.2.1"
+      }
+    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
@@ -6155,6 +6198,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmmirror.com/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmmirror.com/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmmirror.com/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/longest-streak": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@astrojs/cloudflare": "^13.6.1",
     "@astrojs/react": "^5.0.7",
+    "@giscus/react": "^3.1.0",
     "astro": "^6.4.4",
     "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",

--- a/src/components/LegalArticle.astro
+++ b/src/components/LegalArticle.astro
@@ -26,7 +26,7 @@ const { locale, title, intro, sections } = Astro.props;
 const t = getMessages(locale);
 
 const GITHUB_REPO = "https://github.com/Sallyn0225/seatview";
-const LAST_UPDATED = "2026-05-25";
+const LAST_UPDATED = "2026-06-11";
 
 const updated = t.legal.updated.replace("{date}", LAST_UPDATED);
 // Split the feedback line around the {github} slot for the inline repo link.

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -20,6 +20,14 @@ interface CloudflareEnv {
   // stored `image_key` is appended to this to build a fetchable URL
   // (src/lib/photos.ts imageKeyToUrl). Empty/absent → same-origin /r2/ fallback.
   PUBLIC_R2_BASE_URL?: string;
+  // giscus venue comments (task 06-10-giscus). Non-secret resource identifiers;
+  // the client reads the build-time copies from .env* — these are the runtime
+  // parity copies (wrangler.jsonc `vars`). CATEGORY_ID is empty until the
+  // GitHub-side setup is done (research/giscus-setup-steps.md).
+  PUBLIC_GISCUS_REPO?: string;
+  PUBLIC_GISCUS_REPO_ID?: string;
+  PUBLIC_GISCUS_CATEGORY?: string;
+  PUBLIC_GISCUS_CATEGORY_ID?: string;
   // Secrets (set via `wrangler secret put` / .dev.vars; optional at type level
   // because they are absent until configured).
   TURNSTILE_SECRET_KEY?: string;
@@ -56,6 +64,10 @@ interface ImportMetaEnv {
   readonly PUBLIC_TURNSTILE_SITE_KEY: string;
   readonly PUBLIC_SITE_URL: string;
   readonly PUBLIC_R2_BASE_URL?: string;
+  readonly PUBLIC_GISCUS_REPO?: string;
+  readonly PUBLIC_GISCUS_REPO_ID?: string;
+  readonly PUBLIC_GISCUS_CATEGORY?: string;
+  readonly PUBLIC_GISCUS_CATEGORY_ID?: string;
 }
 
 interface ImportMeta {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -215,6 +215,30 @@ const en: Messages = {
       cancel: "Collapse",
     },
   },
+  venueComments: {
+    entryLabel: "Open comments and ratings",
+    entrySummary: "{avg} · {count} ratings",
+    entryEmpty: "No ratings yet",
+    entryComments: "Comments",
+    title: "Comments & ratings",
+    close: "Close",
+    ratingTitle: "Rate this venue",
+    starLabel: "Rate {n} out of 5",
+    ratingSummary: "Average {avg} · {count} ratings",
+    ratingEmpty: "No ratings yet. Want to be the first?",
+    yourScore: "You rated {score}. Tap another star to change it.",
+    ratingNote:
+      "No sign-in needed to rate. For de-duplication we keep only a salted hash of your IP, never the raw IP.",
+    ratingSaved: "Saved.",
+    ratingLimit: "You've rated 10 venues today. Come back tomorrow.",
+    ratingNetworkError: "The connection seems shaky. Try again?",
+    ratingServerError: "That didn't save. Try again later.",
+    commentsTitle: "Comments",
+    commentsNote:
+      "Commenting uses your GitHub account. Reading needs no sign-in.",
+    commentsUnavailable: "Comments aren't open yet.",
+    commentsLoading: "Loading comments…",
+  },
   footer: {
     contribute: "Add a new venue? Submit via GitHub",
     about: "About",
@@ -246,6 +270,10 @@ const en: Messages = {
         body: "Submissions and seconding use Cloudflare Turnstile for human verification. That step is governed by Cloudflare's privacy policy.",
       },
       {
+        heading: "Comments and ratings",
+        body: "Venue comments are provided by the third-party service giscus, loaded as an embedded frame, and stored in the Discussions of our public GitHub repository. Posting a comment requires signing in to GitHub and authorizing giscus; that step is governed by the GitHub and giscus privacy policies. Reading needs no account. Venue ratings need no sign-in either: as with vote de-duplication, we keep only a salted hash of your IP, never the raw IP.",
+      },
+      {
         heading: "Local storage",
         body: "We keep only a few preferences in your browser (light/dark theme, last venue visited, tree expansion state). This data stays on your device and is never sent to us.",
       },
@@ -269,6 +297,10 @@ const en: Messages = {
       {
         heading: "Content moderation",
         body: "We may remove inappropriate, rule-breaking, or disputed submissions without prior notice.",
+      },
+      {
+        heading: "Comments and ratings",
+        body: "Venue comments are stored in GitHub Discussions and are subject to GitHub's terms of service and community guidelines. We may delete, minimize, or lock inappropriate comments and block the accounts involved. Anonymous ratings are for reference only; we may adjust or remove rating data if manipulation is found.",
       },
       {
         heading: "Disclaimer",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -205,6 +205,31 @@ const ja: Messages = {
       cancel: "閉じる",
     },
   },
+  venueComments: {
+    entryLabel: "コメントと評価を開く",
+    entrySummary: "{avg} · {count} 件の評価",
+    entryEmpty: "評価はまだありません",
+    entryComments: "コメント",
+    title: "コメントと評価",
+    close: "閉じる",
+    ratingTitle: "この会場を評価する",
+    starLabel: "星 {n} つ",
+    ratingSummary: "平均 {avg} · {count} 件の評価",
+    ratingEmpty: "まだ評価がありません。最初の一人に、あなたが。",
+    yourScore:
+      "あなたの評価は星 {score} つ。他の星をタップすると変更できます。",
+    ratingNote:
+      "評価にログインは不要です。重複防止のため、ソルト付きでハッシュ化した IP のみを保存し、生の IP は保存しません。",
+    ratingSaved: "記録しました。",
+    ratingLimit: "本日の評価は上限（10会場）に達しました。",
+    ratingNetworkError: "通信が不安定なようです。もう一度試しますか？",
+    ratingServerError: "記録できませんでした。後でお試しください。",
+    commentsTitle: "コメント",
+    commentsNote:
+      "コメントの投稿には GitHub アカウントが必要です。読むだけならログインは不要です。",
+    commentsUnavailable: "コメント欄はまだ準備中です。",
+    commentsLoading: "コメントを読み込み中…",
+  },
   footer: {
     contribute: "新しい会場を提案する？GitHub から",
     about: "このサイトについて",
@@ -236,6 +261,10 @@ const ja: Messages = {
         body: "投稿・賛同の際に Cloudflare Turnstile を使用します。この処理には Cloudflare のプライバシーポリシーが適用されます。",
       },
       {
+        heading: "コメントと評価",
+        body: "会場コメントは第三者サービス giscus を埋め込みで利用し、内容は公開 GitHub リポジトリの Discussions に保存されます。コメントの投稿には GitHub へのログインと giscus の認可が必要で、この処理には GitHub および giscus のプライバシーポリシーが適用されます。閲覧だけならログインは不要です。会場の評価にもログインは不要で、投票の重複防止と同じく、ソルト付きでハッシュ化した IP のみを保存し、生の IP は保存しません。",
+      },
+      {
         heading: "ローカルストレージ",
         body: "テーマ（ライト／ダーク）、最後に見た会場、ツリーの開閉状態など、わずかな設定のみをブラウザのローカルに保存します。これらはお使いの端末内にとどまり、当方へ送信されることはありません。",
       },
@@ -259,6 +288,10 @@ const ja: Messages = {
       {
         heading: "コンテンツの管理",
         body: "不適切・規約違反、または申し立てのあった投稿は、事前の通知なく削除する場合があります。",
+      },
+      {
+        heading: "コメントと評価",
+        body: "会場コメントは GitHub Discussions に保存され、GitHub の利用規約とコミュニティガイドラインが適用されます。不適切なコメントは削除・非表示・ロックし、関連アカウントをブロックすることがあります。匿名の評価は参考情報であり、不正な操作を確認した場合は該当データを調整・削除することがあります。",
       },
       {
         heading: "免責事項",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -212,6 +212,30 @@ const ko: Messages = {
       cancel: "접기",
     },
   },
+  venueComments: {
+    entryLabel: "댓글과 평점 열기",
+    entrySummary: "{avg} · {count}명이 평가",
+    entryEmpty: "아직 평점이 없어요",
+    entryComments: "댓글",
+    title: "댓글과 평점",
+    close: "닫기",
+    ratingTitle: "이 회장을 평가하기",
+    starLabel: "별 {n}개",
+    ratingSummary: "평균 {avg} · {count}명이 평가",
+    ratingEmpty: "아직 평점이 없어요. 첫 번째가 되어 볼까요?",
+    yourScore: "별 {score}개를 주셨어요. 다른 별을 탭하면 바꿀 수 있어요.",
+    ratingNote:
+      "평가에 로그인은 필요 없어요. 중복 방지를 위해 솔트 해시 처리한 IP만 저장하고 원본 IP는 저장하지 않아요.",
+    ratingSaved: "기록했어요.",
+    ratingLimit: "오늘 10개 회장을 평가했어요. 내일 다시 와 주세요.",
+    ratingNetworkError: "연결이 불안정한 것 같아요. 다시 해 볼까요?",
+    ratingServerError: "기록하지 못했어요. 나중에 다시 시도해 주세요.",
+    commentsTitle: "댓글",
+    commentsNote:
+      "댓글 작성에는 GitHub 계정이 필요해요. 읽기만 할 때는 로그인이 필요 없어요.",
+    commentsUnavailable: "댓글란은 아직 준비 중이에요.",
+    commentsLoading: "댓글을 불러오는 중…",
+  },
   footer: {
     contribute: "새 회장을 제안할까요? GitHub로 제출",
     about: "소개",
@@ -243,6 +267,10 @@ const ko: Messages = {
         body: "투고와 동의 시 Cloudflare Turnstile로 사람 여부를 확인해요. 이 단계는 Cloudflare 개인정보 처리방침의 적용을 받아요.",
       },
       {
+        heading: "댓글과 평점",
+        body: "회장 댓글은 제3자 서비스 giscus를 통해 내장 프레임으로 제공되며, 내용은 공개 GitHub 저장소의 Discussions에 저장돼요. 댓글을 쓰려면 GitHub에 로그인하고 giscus를 승인해야 하며, 이 단계에는 GitHub와 giscus의 개인정보 처리방침이 적용돼요. 읽기만 할 때는 로그인이 필요 없어요. 회장 평점도 로그인 없이 가능하며, 투표 중복 방지와 마찬가지로 솔트 해시 처리한 IP만 저장하고 원본 IP는 저장하지 않아요.",
+      },
+      {
         heading: "로컬 저장소",
         body: "테마(라이트/다크), 마지막으로 본 회장, 트리 펼침 상태 등 약간의 설정만 브라우저 로컬에 저장해요. 이 데이터는 기기에만 남고 저희에게 전송되지 않아요.",
       },
@@ -266,6 +294,10 @@ const ko: Messages = {
       {
         heading: "콘텐츠 관리",
         body: "부적절하거나 약관을 위반하거나 신고된 투고는 사전 통지 없이 삭제할 수 있어요.",
+      },
+      {
+        heading: "댓글과 평점",
+        body: "회장 댓글은 GitHub Discussions에 저장되며 GitHub의 이용약관과 커뮤니티 가이드라인이 적용돼요. 부적절한 댓글은 삭제·접기·잠금 처리하고 관련 계정을 차단할 수 있어요. 익명 평점은 참고용이며, 조작이 확인되면 해당 데이터를 조정하거나 삭제할 수 있어요.",
       },
       {
         heading: "면책 조항",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -248,6 +248,49 @@ export interface Messages {
       cancel: string;
     };
   };
+  /** Venue comments + anonymous rating (task 06-10-giscus). */
+  venueComments: {
+    /** Title-area entry chip aria-label. */
+    entryLabel: string;
+    /** Chip rating summary, `{avg}` → 1-decimal average, `{count}` → raters. */
+    entrySummary: string;
+    /** Chip zero state (no ratings yet) — quiet, demoted. */
+    entryEmpty: string;
+    /** Chip trailing word: the comments entry. */
+    entryComments: string;
+    /** Drawer title. */
+    title: string;
+    /** ✕ close button aria-label. */
+    close: string;
+    /** Rating block heading. */
+    ratingTitle: string;
+    /** Star button aria-label, `{n}` → 1..5. */
+    starLabel: string;
+    /** Aggregate line under the stars, `{avg}` + `{count}`. */
+    ratingSummary: string;
+    /** Zero ratings (gentle 缝隙时刻). */
+    ratingEmpty: string;
+    /** Your current score line, `{score}`. */
+    yourScore: string;
+    /** Transparency one-liner: no login, salted IP hash only. */
+    ratingNote: string;
+    /** Inline saved confirmation. */
+    ratingSaved: string;
+    /** Daily cap reached (RATING_DAILY_LIMIT venues). */
+    ratingLimit: string;
+    /** Network failure (inline, rolled back). */
+    ratingNetworkError: string;
+    /** Generic server failure (inline, rolled back). */
+    ratingServerError: string;
+    /** Comments block heading. */
+    commentsTitle: string;
+    /** GitHub-login transparency line above the giscus frame. */
+    commentsNote: string;
+    /** categoryId not configured yet → quiet degraded state. */
+    commentsUnavailable: string;
+    /** SR/status text while the giscus bundle loads. */
+    commentsLoading: string;
+  };
   footer: {
     contribute: string;
     about: string;
@@ -690,6 +733,29 @@ const zh: Messages = {
       cancel: "收起",
     },
   },
+  venueComments: {
+    entryLabel: "打开评论与评分",
+    entrySummary: "{avg} · {count} 人评分",
+    entryEmpty: "暂无评分",
+    entryComments: "评论",
+    title: "评论与评分",
+    close: "关闭",
+    ratingTitle: "给这个场馆打分",
+    starLabel: "{n} 星",
+    ratingSummary: "平均 {avg} · {count} 人评分",
+    ratingEmpty: "还没有人打分。第一个，由你来。",
+    yourScore: "你打了 {score} 星。点其他星可以改分。",
+    ratingNote:
+      "打分无需登录。为了去重，我们只保存加盐哈希后的 IP，不存原 IP。",
+    ratingSaved: "已记录。",
+    ratingLimit: "你今天已经给 10 个场馆打过分了。明天再来。",
+    ratingNetworkError: "网络似乎不稳，再试一次？",
+    ratingServerError: "没记上，稍后再试。",
+    commentsTitle: "评论",
+    commentsNote: "发评论需要 GitHub 账号，只看不用登录。",
+    commentsUnavailable: "评论区暂未开通。",
+    commentsLoading: "评论加载中…",
+  },
   footer: {
     contribute: "想贡献新场馆？通过 GitHub 提交",
     about: "关于",
@@ -721,6 +787,10 @@ const zh: Messages = {
         body: "投稿与附议时使用 Cloudflare Turnstile 进行人机校验，这一环节受 Cloudflare 隐私政策约束。",
       },
       {
+        heading: "评论与评分",
+        body: "场馆评论由第三方服务 giscus 提供，以内嵌页面加载，内容存储在我们公开 GitHub 仓库的 Discussions 中；发表评论需要登录 GitHub 并授权 giscus，这一环节受 GitHub 与 giscus 的隐私政策约束，仅浏览无需登录。场馆评分无需登录，与投票去重相同，我们只保存加盐哈希后的 IP，不存原 IP。",
+      },
+      {
         heading: "本地存储",
         body: "我们仅在你的浏览器本地保存少量偏好（深浅色主题、上次浏览的场馆、目录展开状态）。这些数据只留在你的设备上，不会发送给我们。",
       },
@@ -744,6 +814,10 @@ const zh: Messages = {
       {
         heading: "内容治理",
         body: "我们可在不事先通知的情况下，移除不当、违规或涉及投诉的投稿。",
+      },
+      {
+        heading: "评论与评分",
+        body: "场馆评论存储在 GitHub Discussions 中，需遵守 GitHub 的服务条款与社区准则。我们可以删除、折叠或锁定不当评论，并屏蔽相关账号。匿名评分仅供参考，发现刷分时我们可以调整或清除相关数据。",
       },
       {
         heading: "免责声明",

--- a/src/islands/VenueComments.tsx
+++ b/src/islands/VenueComments.tsx
@@ -1,0 +1,454 @@
+// Venue comments + anonymous rating entry (task 06-10-giscus).
+//
+// One self-contained island mounted in the venue title area: a quiet entry
+// chip ("★4.3 · 12 人评分 · 评论", demoted small text per prd — never a big
+// authoritative star bar) that opens a right drawer (full-screen sheet on
+// mobile, matching UploadSheet's container family). Drawer top = the 5-star
+// anonymous rating control (no login, score change = UPSERT, optimistic
+// update with rollback); below = the giscus comments frame.
+//
+// Lazy mount (prd "懒挂载"): nothing giscus-related — not even the
+// @giscus/react bundle — loads until the drawer first opens (dynamic import +
+// `loading="lazy"`). Closing HIDES the drawer instead of unmounting it so the
+// giscus iframe never reloads on reopen. While the giscus categoryId is not
+// configured yet (PUBLIC_GISCUS_CATEGORY_ID empty), the comments block renders
+// a quiet "not open yet" line and loads no giscus resources at all.
+//
+// Theme: follows the SITE's light/dark class on <html> via a MutationObserver
+// (NOT giscus `preferred_color_scheme`, which tracks the OS and would desync
+// from the site's tri-state ThemeToggle). @giscus/react propagates the theme
+// prop change to the iframe via postMessage without reloading it.
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ComponentType,
+} from "react";
+import { MessageSquare, Star, X } from "lucide-react";
+import type { GiscusProps } from "@giscus/react";
+import type { Locale } from "@/i18n/config";
+import { useLocale } from "@/hooks/useLocale";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import LoadFailure from "@/components/LoadFailure";
+import { fillTemplate } from "@/lib/format";
+import {
+  applyOptimisticRating,
+  ratingAverage,
+  RATING_MAX,
+  RATING_MIN,
+  type VenueRatingSummaryDto,
+} from "@/lib/venue-rating";
+import { RatingError, submitRating } from "@/lib/venue-rating-client";
+import { cn } from "@/lib/utils";
+
+/** giscus widget UI language per site locale (zh → zh-CN, the rest map 1:1). */
+const GISCUS_LANG: Record<Locale, GiscusProps["lang"]> = {
+  zh: "zh-CN",
+  ja: "ja",
+  en: "en",
+  ko: "ko",
+};
+
+// Build-time giscus config, inlined by Vite from .env.development /
+// .env.production (frontend/index.md PUBLIC_* contract — wrangler.jsonc `vars`
+// never reach the client bundle). Non-secret by definition.
+const GISCUS_REPO: string = import.meta.env.PUBLIC_GISCUS_REPO ?? "";
+const GISCUS_REPO_ID: string = import.meta.env.PUBLIC_GISCUS_REPO_ID ?? "";
+const GISCUS_CATEGORY: string = import.meta.env.PUBLIC_GISCUS_CATEGORY ?? "";
+const GISCUS_CATEGORY_ID: string =
+  import.meta.env.PUBLIC_GISCUS_CATEGORY_ID ?? "";
+
+function isRepoSlug(value: string): value is `${string}/${string}` {
+  return /^[^/]+\/[^/]+$/.test(value);
+}
+
+/** Narrowed repo slug, or null when the env var is absent/malformed. */
+const giscusRepo = isRepoSlug(GISCUS_REPO) ? GISCUS_REPO : null;
+
+/** All four giscus ids present → the comments frame may load. */
+const giscusConfigured =
+  giscusRepo !== null &&
+  GISCUS_REPO_ID.length > 0 &&
+  GISCUS_CATEGORY.length > 0 &&
+  GISCUS_CATEGORY_ID.length > 0;
+
+const STARS = Array.from(
+  { length: RATING_MAX - RATING_MIN + 1 },
+  (_, i) => RATING_MIN + i,
+);
+
+const SHEET_ANIM_MS = 250;
+
+type RatingErrorKey = "limit" | "network" | "server";
+
+/**
+ * The site's resolved light/dark theme, kept in sync with the `dark` class on
+ * <html> (written by ThemeToggle + the pre-paint script). SSR snapshot is
+ * "light"; the effect corrects it before the drawer (and giscus) ever opens.
+ */
+function useSiteTheme(): "dark" | "light" {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    const root = document.documentElement;
+    const sync = () => setDark(root.classList.contains("dark"));
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(root, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+  return dark ? "dark" : "light";
+}
+
+interface VenueCommentsProps {
+  locale: Locale;
+  venueId: string;
+  /** SSR-read aggregate (one `venue_rating_agg` row) + this viewer's score. */
+  initialRating: VenueRatingSummaryDto;
+}
+
+export default function VenueComments({
+  locale,
+  venueId,
+  initialRating,
+}: VenueCommentsProps) {
+  const { t } = useLocale(locale);
+  const reducedMotion = usePrefersReducedMotion();
+  const titleId = useId();
+  const theme = useSiteTheme();
+
+  // ── Drawer open state ──────────────────────────────────────────────────────
+  // `everOpened` keeps the drawer MOUNTED (hidden) after the first open so the
+  // giscus iframe survives close/reopen without reloading.
+  const [open, setOpen] = useState(false);
+  const [everOpened, setEverOpened] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const openDrawer = useCallback(() => {
+    setEverOpened(true);
+    setOpen(true);
+  }, []);
+
+  const closeDrawer = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  // Esc to close + body scroll lock + focus into the panel while open.
+  useEffect(() => {
+    if (!open) return;
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") closeDrawer();
+    }
+    document.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    panelRef.current?.focus();
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open, closeDrawer]);
+
+  // ── Rating state (optimistic with rollback) ────────────────────────────────
+  const [summary, setSummary] = useState<VenueRatingSummaryDto>(initialRating);
+  const [ratingPending, setRatingPending] = useState(false);
+  const [ratingError, setRatingError] = useState<RatingErrorKey | null>(null);
+  const [ratingSaved, setRatingSaved] = useState(false);
+
+  const rate = useCallback(
+    (score: number) => {
+      if (ratingPending || summary.yourScore === score) return;
+      const previous = summary;
+
+      setSummary(applyOptimisticRating(previous, score));
+      setRatingPending(true);
+      setRatingError(null);
+      setRatingSaved(false);
+
+      submitRating(venueId, score)
+        .then((res) => {
+          // Reconcile to the authoritative aggregate.
+          setSummary({
+            count: res.ratingCount,
+            sum: res.ratingSum,
+            yourScore: res.yourScore,
+          });
+          setRatingSaved(true);
+        })
+        .catch((err: unknown) => {
+          setSummary(previous); // roll back the optimistic state
+          const code = err instanceof RatingError ? err.code : "server_error";
+          setRatingError(
+            code === "rate_limited_daily"
+              ? "limit"
+              : code === "network"
+                ? "network"
+                : "server",
+          );
+        })
+        .finally(() => setRatingPending(false));
+    },
+    [ratingPending, summary, venueId],
+  );
+
+  // ── giscus lazy load (first open only) ─────────────────────────────────────
+  const [Giscus, setGiscus] = useState<ComponentType<GiscusProps> | null>(null);
+  const [giscusFailed, setGiscusFailed] = useState(false);
+  const [giscusLoading, setGiscusLoading] = useState(false);
+  const giscusRequestedRef = useRef(false);
+
+  const loadGiscus = useCallback(() => {
+    if (giscusRequestedRef.current) return;
+    giscusRequestedRef.current = true;
+    setGiscusFailed(false);
+    setGiscusLoading(true);
+    import("@giscus/react")
+      .then((mod) => {
+        setGiscus(() => mod.default);
+        setGiscusLoading(false);
+      })
+      .catch(() => {
+        // Network failure fetching the chunk — allow LoadFailure's retry to
+        // re-run the import.
+        giscusRequestedRef.current = false;
+        setGiscusFailed(true);
+        setGiscusLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (open && giscusConfigured) loadGiscus();
+  }, [open, loadGiscus]);
+
+  // ── Derived display ────────────────────────────────────────────────────────
+  const average = ratingAverage(summary.count, summary.sum);
+  const ratingErrorText =
+    ratingError === "limit"
+      ? t.venueComments.ratingLimit
+      : ratingError === "network"
+        ? t.venueComments.ratingNetworkError
+        : ratingError === "server"
+          ? t.venueComments.ratingServerError
+          : null;
+
+  return (
+    <>
+      {/* Entry chip: demoted small text, never a big star bar (prd 降权展示). */}
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={openDrawer}
+        aria-label={t.venueComments.entryLabel}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className={cn(
+          "text-muted-foreground hover:text-foreground inline-flex min-h-11 items-center gap-1.5 rounded-sm text-sm",
+          "transition-colors duration-150",
+          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+        )}
+      >
+        <Star
+          className="size-3.5"
+          aria-hidden="true"
+          fill={average !== null ? "currentColor" : "none"}
+        />
+        <span>
+          {average !== null
+            ? fillTemplate(t.venueComments.entrySummary, {
+                avg: average.toFixed(1),
+                count: String(summary.count),
+              })
+            : t.venueComments.entryEmpty}
+        </span>
+        <span aria-hidden="true">·</span>
+        <span className="inline-flex items-center gap-1">
+          <MessageSquare className="size-3.5" aria-hidden="true" />
+          {t.venueComments.entryComments}
+        </span>
+      </button>
+
+      {/* Drawer: mounted from the first open onward, hidden (not unmounted)
+          while closed so the giscus iframe is never reloaded. */}
+      {everOpened ? (
+        <div
+          className={cn("fixed inset-0 z-50 flex", !open && "hidden")}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={titleId}
+        >
+          {/* Ink overlay (not a shadow — a layer of ink). Click to close. */}
+          <button
+            type="button"
+            aria-hidden="true"
+            tabIndex={-1}
+            onClick={closeDrawer}
+            className="absolute inset-0 cursor-default bg-[oklch(0.15_0.008_75_/_0.55)]"
+            style={
+              reducedMotion || !open
+                ? undefined
+                : {
+                    animation: `seatview-overlay-in ${SHEET_ANIM_MS}ms ease-out`,
+                  }
+            }
+          />
+
+          {/* Panel: full-screen sheet on mobile, 480px right drawer on md+. */}
+          <div
+            ref={panelRef}
+            tabIndex={-1}
+            className={cn(
+              "bg-background border-border relative ml-auto flex h-full w-full flex-col outline-none",
+              "md:w-[min(480px,80vw)] md:border-l lg:w-[480px]",
+              open && !reducedMotion && "seatview-sheet-panel",
+            )}
+          >
+            {/* Sticky header */}
+            <div className="border-border bg-background sticky top-0 z-10 flex items-center justify-between border-b px-5 py-4 md:px-6">
+              <h2 id={titleId} className="text-foreground text-lg font-medium">
+                {t.venueComments.title}
+              </h2>
+              <button
+                type="button"
+                onClick={closeDrawer}
+                aria-label={t.venueComments.close}
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-ring -mr-1 grid size-9 place-items-center rounded-md focus-visible:ring-2 focus-visible:outline-none"
+              >
+                <X className="size-5" aria-hidden="true" />
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto px-5 py-5 md:px-6">
+              {/* ── Rating block ──────────────────────────────────────────── */}
+              <section>
+                <h3 className="text-foreground text-sm font-medium">
+                  {t.venueComments.ratingTitle}
+                </h3>
+                <div
+                  role="radiogroup"
+                  aria-label={t.venueComments.ratingTitle}
+                  className="mt-2 flex items-center"
+                >
+                  {STARS.map((n) => {
+                    const filled =
+                      summary.yourScore !== null && n <= summary.yourScore;
+                    return (
+                      <button
+                        key={n}
+                        type="button"
+                        role="radio"
+                        aria-checked={summary.yourScore === n}
+                        aria-label={fillTemplate(t.venueComments.starLabel, {
+                          n: String(n),
+                        })}
+                        disabled={ratingPending}
+                        onClick={() => rate(n)}
+                        className={cn(
+                          "grid size-11 place-items-center rounded-md",
+                          "transition-colors duration-150",
+                          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+                          "disabled:cursor-not-allowed disabled:opacity-60",
+                          filled
+                            ? "text-foreground"
+                            : "text-muted-foreground hover:text-foreground",
+                        )}
+                      >
+                        <Star
+                          className="size-6"
+                          aria-hidden="true"
+                          fill={filled ? "currentColor" : "none"}
+                        />
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <p className="text-muted-foreground mt-2 text-[13px]">
+                  {average !== null
+                    ? fillTemplate(t.venueComments.ratingSummary, {
+                        avg: average.toFixed(1),
+                        count: String(summary.count),
+                      })
+                    : t.venueComments.ratingEmpty}
+                </p>
+                {summary.yourScore !== null ? (
+                  <p className="text-muted-foreground mt-1 text-[13px]">
+                    {fillTemplate(t.venueComments.yourScore, {
+                      score: String(summary.yourScore),
+                    })}
+                  </p>
+                ) : null}
+
+                {/* Inline status: error (rolled back) or saved. */}
+                {ratingErrorText ? (
+                  <p role="alert" className="text-foreground mt-2 text-[13px]">
+                    {ratingErrorText}
+                  </p>
+                ) : ratingSaved ? (
+                  <p
+                    role="status"
+                    className="text-muted-foreground mt-2 text-[13px]"
+                  >
+                    {t.venueComments.ratingSaved}
+                  </p>
+                ) : null}
+
+                {/* Why-transparency (trust without accounts, PRODUCT.md #4). */}
+                <p className="text-muted-foreground mt-3 text-xs leading-relaxed">
+                  {t.venueComments.ratingNote}
+                </p>
+              </section>
+
+              {/* ── Comments block (giscus) ───────────────────────────────── */}
+              <section className="border-border mt-6 border-t pt-5">
+                <h3 className="text-foreground text-sm font-medium">
+                  {t.venueComments.commentsTitle}
+                </h3>
+                <p className="text-muted-foreground mt-1 text-[13px]">
+                  {t.venueComments.commentsNote}
+                </p>
+                <div className="mt-4">
+                  {!giscusConfigured || giscusRepo === null ? (
+                    <p className="text-muted-foreground text-sm">
+                      {t.venueComments.commentsUnavailable}
+                    </p>
+                  ) : giscusFailed ? (
+                    <LoadFailure
+                      locale={locale}
+                      onRetry={loadGiscus}
+                      retrying={giscusLoading}
+                    />
+                  ) : Giscus ? (
+                    <Giscus
+                      id="venue-comments"
+                      repo={giscusRepo}
+                      repoId={GISCUS_REPO_ID}
+                      category={GISCUS_CATEGORY}
+                      categoryId={GISCUS_CATEGORY_ID}
+                      mapping="specific"
+                      term={`venue:${venueId}`}
+                      strict="1"
+                      reactionsEnabled="1"
+                      emitMetadata="0"
+                      inputPosition="top"
+                      theme={theme}
+                      lang={GISCUS_LANG[locale]}
+                      loading="lazy"
+                    />
+                  ) : (
+                    <p role="status" className="text-muted-foreground text-sm">
+                      {t.venueComments.commentsLoading}
+                    </p>
+                  )}
+                </div>
+              </section>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -67,6 +67,8 @@ const canonical = new URL(Astro.url.pathname, siteUrl).href;
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={t.meta.tagline} />
     <meta name="twitter:image" content={ogImage} />
+    <!-- Page-specific head extras (e.g. the venue page's giscus:backlink). -->
+    <slot name="head" />
     <!-- Apply persisted theme before paint to avoid flash (R12). -->
     <script is:inline>
       (() => {

--- a/src/lib/venue-rating-client.ts
+++ b/src/lib/venue-rating-client.ts
@@ -1,0 +1,60 @@
+// Browser-side rating transport (task 06-10-giscus). One call, mirroring
+// staging-client.ts `plusOneStaging`: POST /api/rating, NOT retried (a 4xx is
+// a real rejection: invalid input or the daily cap). User-facing prose stays
+// in i18n; the API returns stable codes which the rating control maps to
+// localized inline copy (R9).
+
+import type {
+  RatingErrorCode,
+  RatingRequest,
+  RatingResponse,
+} from "@/lib/venue-rating";
+
+/** A typed transport failure the rating control maps to localized copy. */
+export class RatingError extends Error {
+  constructor(
+    readonly code: RatingErrorCode | "network",
+    readonly status?: number,
+  ) {
+    super(code);
+    this.name = "RatingError";
+  }
+}
+
+async function parseErrorCode(
+  res: Response,
+): Promise<RatingErrorCode | "network"> {
+  try {
+    const data = (await res.json()) as { error?: RatingErrorCode };
+    return data.error ?? "server_error";
+  } catch {
+    return "server_error";
+  }
+}
+
+/**
+ * Submit (or change) this viewer's score for a venue. Resolves with the
+ * authoritative aggregate so the caller can reconcile its optimistic state.
+ */
+export async function submitRating(
+  venueId: string,
+  score: number,
+  signal?: AbortSignal,
+): Promise<RatingResponse> {
+  const body: RatingRequest = { venueId, score };
+  let res: Response;
+  try {
+    res = await fetch("/api/rating", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal,
+    });
+  } catch {
+    throw new RatingError("network");
+  }
+  if (!res.ok) {
+    throw new RatingError(await parseErrorCode(res), res.status);
+  }
+  return (await res.json()) as RatingResponse;
+}

--- a/src/lib/venue-rating.test.ts
+++ b/src/lib/venue-rating.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  applyOptimisticRating,
+  isValidRatingScore,
+  ratingAverage,
+  RATING_MAX,
+  RATING_MIN,
+  type VenueRatingSummaryDto,
+} from "./venue-rating.ts";
+
+// These pure helpers ARE the rating math contract: the server's batch writes
+// (src/server/ratings.ts) and the island's optimistic state both follow the
+// transitions asserted here, so a drift in either is a failure of this spec.
+
+describe("isValidRatingScore", () => {
+  it("accepts every integer in RATING_MIN..RATING_MAX", () => {
+    for (let n = RATING_MIN; n <= RATING_MAX; n++) {
+      assert.equal(isValidRatingScore(n), true);
+    }
+  });
+
+  it("rejects out-of-range integers", () => {
+    assert.equal(isValidRatingScore(RATING_MIN - 1), false);
+    assert.equal(isValidRatingScore(RATING_MAX + 1), false);
+    assert.equal(isValidRatingScore(-3), false);
+  });
+
+  it("rejects non-integers and non-numbers", () => {
+    assert.equal(isValidRatingScore(3.5), false);
+    assert.equal(isValidRatingScore(Number.NaN), false);
+    assert.equal(isValidRatingScore("3"), false);
+    assert.equal(isValidRatingScore(null), false);
+    assert.equal(isValidRatingScore(undefined), false);
+    assert.equal(isValidRatingScore(true), false);
+  });
+});
+
+describe("ratingAverage", () => {
+  it("returns null when nobody rated (callers render the zero state)", () => {
+    assert.equal(ratingAverage(0, 0), null);
+  });
+
+  it("rounds to one decimal", () => {
+    assert.equal(ratingAverage(3, 13), 4.3); // 4.333…
+    assert.equal(ratingAverage(3, 14), 4.7); // 4.666…
+    assert.equal(ratingAverage(2, 9), 4.5);
+    assert.equal(ratingAverage(1, 5), 5);
+  });
+});
+
+describe("applyOptimisticRating", () => {
+  const fresh: VenueRatingSummaryDto = { count: 12, sum: 51, yourScore: null };
+
+  it("new rating: count + 1, sum + score, yourScore set", () => {
+    assert.deepEqual(applyOptimisticRating(fresh, 4), {
+      count: 13,
+      sum: 55,
+      yourScore: 4,
+    });
+  });
+
+  it("score change: count unchanged, sum moves by the delta", () => {
+    const rated: VenueRatingSummaryDto = { count: 13, sum: 55, yourScore: 4 };
+    assert.deepEqual(applyOptimisticRating(rated, 2), {
+      count: 13,
+      sum: 53, // 55 - 4 + 2
+      yourScore: 2,
+    });
+  });
+
+  it("same score: idempotent no-op (no count or sum drift)", () => {
+    const rated: VenueRatingSummaryDto = { count: 13, sum: 55, yourScore: 4 };
+    assert.deepEqual(applyOptimisticRating(rated, 4), rated);
+  });
+
+  it("first rating on an unrated venue starts the aggregate", () => {
+    const empty: VenueRatingSummaryDto = { count: 0, sum: 0, yourScore: null };
+    assert.deepEqual(applyOptimisticRating(empty, 5), {
+      count: 1,
+      sum: 5,
+      yourScore: 5,
+    });
+  });
+
+  it("does not mutate the input summary (rollback keeps the original)", () => {
+    const before: VenueRatingSummaryDto = { count: 2, sum: 7, yourScore: null };
+    applyOptimisticRating(before, 3);
+    assert.deepEqual(before, { count: 2, sum: 7, yourScore: null });
+  });
+});

--- a/src/lib/venue-rating.ts
+++ b/src/lib/venue-rating.ts
@@ -1,0 +1,108 @@
+// Shared venue-rating contract — the cross-layer source of truth for the
+// anonymous 1..5-star venue rating (task 06-10-giscus, prd "评分后端").
+// The rating control (client), the /api/rating route (server) and the D1
+// `venue_ratings` / `venue_rating_agg` rows all agree on these names + limits
+// here so a field cannot drift between layers (cross-layer-thinking-guide).
+//
+// Deliberately NO Turnstile field: like the staging "+1" (staging/vote.ts), a
+// rating is a single click and abuse is bounded by UNIQUE(venue_id, ip_hash)
+// dedup-as-UPSERT + the KV daily cap, not a per-click challenge.
+
+/** Valid score bounds (inclusive). */
+export const RATING_MIN = 1;
+export const RATING_MAX = 5;
+
+/**
+ * Daily cap per IP: at most 10 DIFFERENT venues newly rated per UTC day (KV
+ * `rating` scope). Changing an existing score does NOT consume quota — the
+ * UPSERT touches the same row, so there is nothing new to flood with.
+ */
+export const RATING_DAILY_LIMIT = 10;
+
+/** Type guard: an integer score within RATING_MIN..RATING_MAX. */
+export function isValidRatingScore(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= RATING_MIN &&
+    value <= RATING_MAX
+  );
+}
+
+/** POST /api/rating body. */
+export interface RatingRequest {
+  venueId: string;
+  score: number;
+}
+
+/**
+ * POST /api/rating success body: the authoritative aggregate after the write.
+ * Returned for a fresh rating, a score change AND an idempotent same-score
+ * repeat, so the client reconciles its optimistic state to this value.
+ */
+export interface RatingResponse {
+  venueId: string;
+  ratingCount: number;
+  ratingSum: number;
+  yourScore: number;
+}
+
+/**
+ * Per-viewer rating summary, SSR-injected into the venue page (one agg-row
+ * read; PRD: the display path never aggregates over `venue_ratings`).
+ */
+export interface VenueRatingSummaryDto {
+  /** How many different IPs rated this venue. */
+  count: number;
+  /** Sum of all scores (avg = sum / count). */
+  sum: number;
+  /** THIS viewer's current score (by ip_hash), null when not rated yet. */
+  yourScore: number | null;
+}
+
+/**
+ * Stable machine error codes returned as `{ error: <code> }`. The CLIENT maps
+ * these to localized inline copy (R9) — the API never sends prose.
+ */
+export type RatingErrorCode =
+  | "missing_fields"
+  | "venue_not_found"
+  | "rate_limited_daily" // RATING_DAILY_LIMIT new venues rated today
+  | "database_unavailable"
+  | "server_misconfigured"
+  | "server_error";
+
+/**
+ * Average score rounded to one decimal, or null when nobody rated yet (callers
+ * render their zero state instead of a fake 0.0).
+ */
+export function ratingAverage(count: number, sum: number): number | null {
+  if (count <= 0) return null;
+  return Math.round((sum / count) * 10) / 10;
+}
+
+/**
+ * Pure optimistic-apply for the rating control: the same transition the server
+ * performs in D1 (new rating → count+1, sum+score; score change → count stays,
+ * sum moves by the delta; same score → no-op). Keeping this in the shared
+ * contract means the client's optimistic state can never disagree with the
+ * server's batch math.
+ */
+export function applyOptimisticRating(
+  summary: VenueRatingSummaryDto,
+  score: number,
+): VenueRatingSummaryDto {
+  if (summary.yourScore === null) {
+    return {
+      count: summary.count + 1,
+      sum: summary.sum + score,
+      yourScore: score,
+    };
+  }
+  if (summary.yourScore === score) return summary;
+  return {
+    count: summary.count,
+    sum: summary.sum - summary.yourScore + score,
+    yourScore: score,
+  };
+}

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -13,6 +13,7 @@ import VenueTreeDrawer from "@/islands/VenueTreeDrawer.tsx";
 import VenueSearch from "@/islands/VenueSearch.tsx";
 import SubMapTabs from "@/islands/SubMapTabs.tsx";
 import VenueMain from "@/islands/VenueMain.tsx";
+import VenueComments from "@/islands/VenueComments.tsx";
 import { asLocale } from "@/i18n/config";
 import { getMessages, venueName } from "@/i18n";
 import { getVenue } from "@/data/venues";
@@ -20,9 +21,12 @@ import { getPrefecture, prefectureName } from "@/data/prefectures";
 import { readSubMapFromUrl, resolveInitialSubMapId } from "@/lib/submap";
 import { STORAGE_KEYS } from "@/lib/storage";
 import { env } from "cloudflare:workers";
+import { clientIp, hashIp } from "@/server/ip";
 import { getDb } from "@/server/db";
 import { listSubMapPhotos } from "@/server/photos";
+import { getRatingSummary } from "@/server/ratings";
 import type { PhotoDto } from "@/lib/photos";
+import type { VenueRatingSummaryDto } from "@/lib/venue-rating";
 
 export const prerender = false;
 
@@ -62,9 +66,42 @@ if (venue && initialSubMapId && env.DB) {
 
 const prefecture = venue ? getPrefecture(venue.prefecture) : undefined;
 const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
+
+// SSR-read the venue rating aggregate (ONE `venue_rating_agg` row — never an
+// AVG over rating rows) + this viewer's own score (by salted ip_hash, same
+// privacy model as staging votedByMe). Fails soft to a zero summary so a D1
+// hiccup never 500s the page; the entry chip then shows its zero state.
+let ratingSummary: VenueRatingSummaryDto = { count: 0, sum: 0, yourScore: null };
+if (venue && env.DB) {
+  try {
+    const viewerIpHash = env.TURNSTILE_SECRET_KEY
+      ? await hashIp(clientIp(Astro.request), env.TURNSTILE_SECRET_KEY)
+      : undefined;
+    ratingSummary = await getRatingSummary(
+      getDb(env.DB),
+      venue.id,
+      viewerIpHash,
+    );
+  } catch {
+    ratingSummary = { count: 0, sum: 0, yourScore: null };
+  }
+}
+
+// Canonical per-language venue URL for the giscus Discussion backlink. Without
+// this meta, giscus records whatever URL (incl. ?tab=) first triggered the
+// Discussion creation (research giscus-deep-dive §1).
+const siteUrl = import.meta.env.PUBLIC_SITE_URL ?? Astro.url.origin;
+const giscusBacklink = venue
+  ? new URL(`/${locale}/v/${venue.id}`, siteUrl).href
+  : undefined;
 ---
 
 <Layout locale={locale} title={title}>
+  {
+    venue && giscusBacklink ? (
+      <meta slot="head" name="giscus:backlink" content={giscusBacklink} />
+    ) : null
+  }
   {
     venue ? (
       <Fragment>
@@ -266,6 +303,17 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
               <p class="text-muted-foreground mt-1 text-sm">
                 {venue.name_romaji}
               </p>
+
+              {/* Comments + rating entry (task 06-10-giscus): a quiet demoted
+                  chip, never a big star bar. Opens the drawer island. */}
+              <div class="mt-1">
+                <VenueComments
+                  locale={locale}
+                  venueId={venue.id}
+                  initialRating={ratingSummary}
+                  client:idle
+                />
+              </div>
 
               <div class="border-border mt-4 border-b pb-1">
                 <SubMapTabs

--- a/src/pages/api/rating.ts
+++ b/src/pages/api/rating.ts
@@ -1,0 +1,120 @@
+// /api/rating — record (or change) an anonymous 1..5-star venue rating.
+//
+// POST { venueId, score } → 200 { venueId, ratingCount, ratingSum, yourScore }.
+// Mirrors /api/staging/vote: NO Turnstile (a single click; a challenge per
+// rating would wreck the UX). Abuse is bounded by UNIQUE(venue_id, ip_hash) in
+// D1 (a repeat rating is a score CHANGE, never a second row) + a KV daily cap
+// on NEW venues rated (RATING_DAILY_LIMIT; changing a score consumes no
+// quota, and quota is consumed only AFTER the D1 write succeeds). The salted
+// IP hash (server/ip) is the only abuse key; the raw IP is never stored.
+// Stable error codes only — i18n lives client side (R9).
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { clientIp, hashIp } from "@/server/ip";
+import { getDb } from "@/server/db";
+import { getViewerScore, rateVenue } from "@/server/ratings";
+import { checkDailyLimit, incrementDaily } from "@/server/rate-limit";
+import { getVenue } from "@/data/venues";
+import {
+  RATING_DAILY_LIMIT,
+  isValidRatingScore,
+  type RatingErrorCode,
+  type RatingRequest,
+  type RatingResponse,
+} from "@/lib/venue-rating";
+
+export const prerender = false;
+
+function jsonError(code: RatingErrorCode, status: number): Response {
+  return new Response(JSON.stringify({ error: code }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  // TURNSTILE_SECRET_KEY doubles as the IP-hash salt (server/ip.ts) — required
+  // even though rating skips Turnstile verification itself.
+  const secret = env.TURNSTILE_SECRET_KEY;
+  if (!secret) {
+    console.error("[rating] TURNSTILE_SECRET_KEY missing");
+    return jsonError("server_misconfigured", 503);
+  }
+  if (!env.DB) {
+    console.error("[rating] DB binding missing");
+    return jsonError("database_unavailable", 503);
+  }
+  if (!env.RATE_LIMIT) {
+    console.error("[rating] RATE_LIMIT binding missing");
+    return jsonError("server_misconfigured", 503);
+  }
+
+  let body: Partial<RatingRequest>;
+  try {
+    body = (await request.json()) as Partial<RatingRequest>;
+  } catch {
+    return jsonError("missing_fields", 400);
+  }
+  const venueId = typeof body.venueId === "string" ? body.venueId.trim() : "";
+  if (venueId.length === 0 || !isValidRatingScore(body.score)) {
+    return jsonError("missing_fields", 400);
+  }
+  // Ratings only attach to venues that exist in the static atlas (ADR-1) — D1
+  // has no venues table, so the bundled set is the referential check.
+  if (!getVenue(venueId)) {
+    return jsonError("venue_not_found", 404);
+  }
+  const score = body.score;
+
+  const ipHash = await hashIp(clientIp(request), secret);
+
+  try {
+    const db = getDb(env.DB);
+
+    // The daily cap only guards NEW venues rated today; changing an existing
+    // score must keep working even at the cap (it creates nothing new).
+    const existing = await getViewerScore(db, venueId, ipHash);
+    if (existing === null) {
+      const limit = await checkDailyLimit(
+        env.RATE_LIMIT,
+        "rating",
+        ipHash,
+        RATING_DAILY_LIMIT,
+      );
+      if (!limit.allowed) {
+        console.warn("[rating] daily limit hit", { ipHash });
+        return jsonError("rate_limited_daily", 429);
+      }
+    }
+
+    const outcome = await rateVenue(db, venueId, ipHash, score);
+
+    // Quota is consumed only after the protected write succeeds (rate-limit
+    // contract), and only for a genuinely new rating. Best-effort, matching
+    // staging/upload/photo-corrections: a counter write failure must not fail
+    // an already-persisted rating (the client would roll back a saved score).
+    if (outcome.status === "created") {
+      try {
+        await incrementDaily(env.RATE_LIMIT, "rating", ipHash);
+      } catch (err) {
+        console.warn("[rating] rate-limit bookkeeping failed", {
+          err: String(err),
+        });
+      }
+    }
+
+    const payload: RatingResponse = {
+      venueId,
+      ratingCount: outcome.ratingCount,
+      ratingSum: outcome.ratingSum,
+      yourScore: score,
+    };
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    console.error("[rating] rating failed", { err: String(err) });
+    return jsonError("database_unavailable", 502);
+  }
+};

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -84,6 +84,45 @@ export const stagingVotes = sqliteTable(
   ],
 );
 
+/**
+ * One anonymous 1..5-star rating of a collected venue (task 06-10-giscus).
+ * The rated venue is a STATIC venue id (data/venues/*.json, ADR-1), validated
+ * against the bundled set at the API layer — D1 has no venues table to FK.
+ *
+ * `UNIQUE(venue_id, ip_hash)` makes the rating per-IP-per-venue: a repeat
+ * submission is a score CHANGE (UPSERT), never a second row, so one IP can
+ * never inflate the count. `ip_hash` is the salted hash (server/ip.ts), never
+ * the raw IP, and is never sent to clients.
+ */
+export const venueRatings = sqliteTable(
+  "venue_ratings",
+  {
+    id: text("id").primaryKey(), // ulid
+    venueId: text("venue_id").notNull(),
+    score: integer("score").notNull(), // 1..5, validated at the API layer
+    ipHash: text("ip_hash").notNull(),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at"), // last score change, null = never changed
+  },
+  (table) => [
+    uniqueIndex("idx_venue_ratings_dedup").on(table.venueId, table.ipHash),
+  ],
+);
+
+/**
+ * Denormalized rating aggregate, 1 row per rated venue. The display path (venue
+ * page SSR) reads exactly this row — never `AVG()` over `venue_ratings` (D1
+ * bills rows read; same reasoning as `stagingVenues.voteCount`). Kept in sync
+ * with `venue_ratings` in the SAME `db.batch` as every rating write (atomic).
+ * `rating_sum` is an integer so `avg = sum / count` avoids stored floats.
+ */
+export const venueRatingAgg = sqliteTable("venue_rating_agg", {
+  venueId: text("venue_id").primaryKey(),
+  ratingCount: integer("rating_count").notNull().default(0),
+  ratingSum: integer("rating_sum").notNull().default(0),
+  updatedAt: integer("updated_at").notNull(),
+});
+
 /** Anonymous request to correct one uploaded photo's seat label. */
 export const photoCorrectionRequests = sqliteTable(
   "photo_correction_requests",
@@ -120,3 +159,6 @@ export type PhotoCorrectionRequestRow =
   typeof photoCorrectionRequests.$inferSelect;
 export type NewPhotoCorrectionRequestRow =
   typeof photoCorrectionRequests.$inferInsert;
+export type VenueRatingRow = typeof venueRatings.$inferSelect;
+export type NewVenueRatingRow = typeof venueRatings.$inferInsert;
+export type VenueRatingAggRow = typeof venueRatingAgg.$inferSelect;

--- a/src/server/rate-limit.ts
+++ b/src/server/rate-limit.ts
@@ -18,7 +18,7 @@
 import type { KVNamespace } from "@cloudflare/workers-types";
 
 /** A day-scoped quota scope. New scopes reuse the same machinery. */
-export type RateScope = "upload" | "staging" | "photo_correction";
+export type RateScope = "upload" | "staging" | "photo_correction" | "rating";
 
 export interface DailyLimitResult {
   /** Whether the current count is still under the limit. */

--- a/src/server/ratings.ts
+++ b/src/server/ratings.ts
@@ -1,0 +1,208 @@
+// D1 queries for the anonymous venue rating (task 06-10-giscus).
+//
+// Mirrors src/server/staging.ts in shape: a read helper (the SSR summary) and
+// a write helper (UPSERT one rating + keep the denormalized aggregate in the
+// SAME atomic `db.batch`). The rated venue id is STATIC metadata
+// (data/venues/*.json, ADR-1) and is validated by the API route against the
+// bundled set — D1 never stores venues, only ratings.
+//
+// Consistency model (why every write is one batch):
+//   • new rating  → INSERT rating row + agg upsert (count+1, sum+score). A
+//     concurrent duplicate fails the rating row's UNIQUE index, which rolls
+//     the whole batch back (agg never drifts) — same backstop as
+//     staging.addVote.
+//   • score change → the agg statement derives the OLD score from the rating
+//     row itself via a subquery INSIDE the batch (never from a pre-read that
+//     could be stale by write time — same "no stale pre-read" rule as the
+//     photo-corrections approve path), then the row update overwrites it.
+// `ip_hash` is the salted hash (server/ip.ts), never the raw IP, and is never
+// sent to the client.
+
+import { and, eq, sql } from "drizzle-orm";
+import type { Db } from "@/server/db";
+import type { VenueRatingSummaryDto } from "@/lib/venue-rating";
+import { newId } from "@/server/id";
+import { venueRatingAgg, venueRatings } from "@/server/db/schema";
+
+/** Outcome of a {@link rateVenue} attempt — mapped to HTTP by the endpoint. */
+export type RateVenueOutcome = {
+  /** `created` consumes daily quota; `updated`/`unchanged` do not. */
+  status: "created" | "updated" | "unchanged";
+  ratingCount: number;
+  ratingSum: number;
+};
+
+/**
+ * Read the display aggregate (1 indexed row — NEVER an AVG over the rating
+ * rows) plus, when the viewer's ip_hash is known, their own current score so
+ * the star control can render the "you rated N" state.
+ */
+export async function getRatingSummary(
+  db: Db,
+  venueId: string,
+  viewerIpHash?: string,
+): Promise<VenueRatingSummaryDto> {
+  const agg = (
+    await db
+      .select({
+        ratingCount: venueRatingAgg.ratingCount,
+        ratingSum: venueRatingAgg.ratingSum,
+      })
+      .from(venueRatingAgg)
+      .where(eq(venueRatingAgg.venueId, venueId))
+      .limit(1)
+  )[0];
+
+  let yourScore: number | null = null;
+  if (viewerIpHash) {
+    yourScore = await getViewerScore(db, venueId, viewerIpHash);
+  }
+
+  return {
+    count: agg?.ratingCount ?? 0,
+    sum: agg?.ratingSum ?? 0,
+    yourScore,
+  };
+}
+
+/** This viewer's current score for a venue, or null when not rated yet. */
+export async function getViewerScore(
+  db: Db,
+  venueId: string,
+  ipHash: string,
+): Promise<number | null> {
+  const row = (
+    await db
+      .select({ score: venueRatings.score })
+      .from(venueRatings)
+      .where(
+        and(eq(venueRatings.venueId, venueId), eq(venueRatings.ipHash, ipHash)),
+      )
+      .limit(1)
+  )[0];
+  return row?.score ?? null;
+}
+
+/** Authoritative post-write aggregate (the response the client reconciles to). */
+async function readAgg(
+  db: Db,
+  venueId: string,
+): Promise<{ ratingCount: number; ratingSum: number }> {
+  const agg = (
+    await db
+      .select({
+        ratingCount: venueRatingAgg.ratingCount,
+        ratingSum: venueRatingAgg.ratingSum,
+      })
+      .from(venueRatingAgg)
+      .where(eq(venueRatingAgg.venueId, venueId))
+      .limit(1)
+  )[0];
+  return { ratingCount: agg?.ratingCount ?? 0, ratingSum: agg?.ratingSum ?? 0 };
+}
+
+/**
+ * Apply a score CHANGE for an existing (venueId, ipHash) rating. The aggregate
+ * statement reads the old score from the rating row itself (subquery) inside
+ * the atomic batch, so a concurrent change can never make the tally drift —
+ * statements in one batch see a consistent row, and D1 serializes batches.
+ * Statement order matters: the agg update must run BEFORE the row update so
+ * the subquery still sees the old score.
+ */
+async function applyScoreChange(
+  db: Db,
+  venueId: string,
+  ipHash: string,
+  score: number,
+  now: number,
+): Promise<void> {
+  const oldScore = sql`(select ${venueRatings.score} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
+  await db.batch([
+    db
+      .update(venueRatingAgg)
+      .set({
+        ratingSum: sql`${venueRatingAgg.ratingSum} + ${score} - ${oldScore}`,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(venueRatingAgg.venueId, venueId),
+          sql`exists (select 1 from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`,
+        ),
+      ),
+    db
+      .update(venueRatings)
+      .set({ score, updatedAt: now })
+      .where(
+        and(eq(venueRatings.venueId, venueId), eq(venueRatings.ipHash, ipHash)),
+      ),
+  ]);
+}
+
+/**
+ * Record (or change) one viewer's score for a venue:
+ *   1. no rating yet → insert + agg(count+1, sum+score) atomically → `created`
+ *   2. same score already recorded → idempotent no-op → `unchanged`
+ *   3. different score → change row + move agg sum by the delta → `updated`
+ * The UNIQUE(venue_id, ip_hash) index is the race backstop for case 1: a
+ * concurrent duplicate insert fails the batch (rolled back, agg untouched) and
+ * is retried as a score change. Always returns the authoritative aggregate.
+ */
+export async function rateVenue(
+  db: Db,
+  venueId: string,
+  ipHash: string,
+  score: number,
+  now: number = Date.now(),
+): Promise<RateVenueOutcome> {
+  const existing = await getViewerScore(db, venueId, ipHash);
+
+  if (existing === null) {
+    try {
+      await db.batch([
+        db.insert(venueRatings).values({
+          id: newId(),
+          venueId,
+          score,
+          ipHash,
+          createdAt: now,
+        }),
+        db
+          .insert(venueRatingAgg)
+          .values({
+            venueId,
+            ratingCount: 1,
+            ratingSum: score,
+            updatedAt: now,
+          })
+          .onConflictDoUpdate({
+            target: venueRatingAgg.venueId,
+            set: {
+              ratingCount: sql`${venueRatingAgg.ratingCount} + 1`,
+              ratingSum: sql`${venueRatingAgg.ratingSum} + ${score}`,
+              updatedAt: now,
+            },
+          }),
+      ]);
+      return { status: "created", ...(await readAgg(db, venueId)) };
+    } catch (err) {
+      // Only a UNIQUE collision (concurrent first rating from the same ip_hash)
+      // falls through to the change path; re-throw real D1 failures so the
+      // endpoint surfaces a 5xx rather than a fake success.
+      if (!String(err).includes("UNIQUE")) throw err;
+      const fresh = await getViewerScore(db, venueId, ipHash);
+      if (fresh === score) {
+        return { status: "unchanged", ...(await readAgg(db, venueId)) };
+      }
+      await applyScoreChange(db, venueId, ipHash, score, now);
+      return { status: "updated", ...(await readAgg(db, venueId)) };
+    }
+  }
+
+  if (existing === score) {
+    return { status: "unchanged", ...(await readAgg(db, venueId)) };
+  }
+
+  await applyScoreChange(db, venueId, ipHash, score, now);
+  return { status: "updated", ...(await readAgg(db, venueId)) };
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -120,6 +120,14 @@
     "PUBLIC_SITE_URL": "https://seat.genchi.top",
     // Public-read base URL for uploaded R2 images (custom domain / r2.dev).
     // image_key is appended to build the fetchable URL (src/lib/photos.ts).
-    "PUBLIC_R2_BASE_URL": "https://img.genchi.top"
+    "PUBLIC_R2_BASE_URL": "https://img.genchi.top",
+    // giscus venue comments (task 06-10-giscus) — runtime parity copy of the
+    // .env.production values (islands read the BUILD-time copy; keep in sync).
+    // categoryId confirmed via GraphQL after the maintainer completed the
+    // GitHub-side setup (see research/giscus-setup-steps.md in the task dir).
+    "PUBLIC_GISCUS_REPO": "Sallyn0225/seatview",
+    "PUBLIC_GISCUS_REPO_ID": "R_kgDOSmjr3g",
+    "PUBLIC_GISCUS_CATEGORY": "Venue Comments",
+    "PUBLIC_GISCUS_CATEGORY_ID": "DIC_kwDOSmjr3s4C-6z6"
   }
 }


### PR DESCRIPTION
## 概要

场馆详情页新增评论与评分（task 06-10-giscus）：

- **评论（giscus）**：标题区入口 chip → 右侧抽屉（移动端全屏 Sheet）。`mapping="specific"` + `term="venue:<id>"` + `strict="1"`，同一场馆在任意 sub-map tab / 任意语言路径下共享同一评论串。首次打开抽屉才懒挂载（首屏零 giscus 资源），关闭隐藏不卸载（iframe 不重载）；主题经 `html.dark` MutationObserver 跟随站点亮暗；giscus UI 语言随站点 locale（zh→zh-CN）。`giscus.json` 锁定允许嵌入的 origins（**合并到 main 后才生效**）。
- **评分（自建 D1，免登录）**：`venue_ratings`（UNIQUE(venue_id, ip_hash)，重复打分 = 改分）+ `venue_rating_agg` 反范式聚合表，UPSERT 与聚合更新在同一原子 batch（migration `0005`）。`POST /api/rating` 复刻 staging/vote 模式：盐化 IP 哈希、KV 日限额仅计新场馆（best-effort 记账）、稳定错误码；venue 页 SSR 只读聚合 1 行（fail-soft）。入口 chip 降权展示「★均分 · N 人评分」，打分乐观更新。
- **配套**：四语 venueComments 文案；隐私/条款页补充第三方评论 iframe（GitHub OAuth/Discussions）与评分 IP 哈希说明；`PUBLIC_GISCUS_*` 配置贯通 `.env.*` / `wrangler.jsonc` vars / `env.d.ts`（categoryId 已回填真实值 `DIC_kwDOSmjr3s4C-6z6`）。

## 验证

- `npm run typecheck`（astro check）0 错误；`npm run format:check` 通过；`npm run test` 18/18；`npm run build` 通过
- 懒加载产物层验证：giscus 独立 chunk，未开抽屉时页面零 giscus.app 引用
- 本地 worker + D1 冒烟：首评 → 改分（sum 移动、count 不变）→ 同分幂等 → 第二 IP 聚合正确；400/404/429 错误路径符合预期
- `npm run db:migrate:local` 已应用 `0005_venue_ratings.sql`
- trellis-check 复核通过（修复 1 处：KV 配额记账改为 best-effort，避免已持久化评分被客户端误回滚）

## 合并前注意

- [ ] **先跑 `npm run db:migrate:prod`** 把 `0005_venue_ratings.sql` 应用到生产 D1（migration 刻意不进 CD；rating API 在表缺失时返回 5xx，venue 页 SSR 读为 fail-soft 不受影响）
- 合并即触发 CD 部署到 seat.genchi.top；giscus 仓库侧已就绪（Discussions 已开、Venue Comments 分类已建、giscus App 已装）
- 上线后冒烟清单见 `.trellis/tasks/06-10-giscus/research/giscus-setup-steps.md` 步骤 7