### PR TITLE
build(deps): bump vite to 7.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9216,9 +9216,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmmirror.com/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmmirror.com/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "wrangler": "^4.100.0"
   },
   "overrides": {
-    "vite": "^7.3.2",
+    "vite": "^7.3.5",
     "@esbuild-kit/core-utils": {
       "esbuild": "^0.25.12"
     },


### PR DESCRIPTION
## Summary
- bump the Vite override from ^7.3.2 to ^7.3.5
- regenerate package-lock.json so the resolved Vite version is 7.3.5

## Security
- fixes Dependabot alert #8: GHSA-fx2h-pf6j-xcff / CVE-2026-53571

## Validation
- npm ci
- npm run typecheck
- npm test
- npm run build
- npm audit output no longer includes GHSA-fx2h-pf6j-xcff / CVE-2026-53571