### PR TITLE
fix(deps): patch ws for security alert #5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10239,9 +10239,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "wrangler": "^4.100.0"
   },
   "overrides": {
+    "ws": "^8.21.0",
     "vite": "^7.3.5",
     "@esbuild-kit/core-utils": {
       "esbuild": "^0.25.12"


### PR DESCRIPTION
Fix GitHub Security and quality Dependabot alert #5 (GHSA-96hv-2xvq-fx4p / CVE-2026-48779) by overriding ws to 8.21.0.

Scope is intentionally minimal:
- package.json override for ws
- package-lock.json refresh only
- no app/runtime behavior changes

Validation:
- npm ls ws
- npm run build
- npm test