### PR TITLE
Split venue rating dimensions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -67,7 +67,7 @@ The core experience is just two steps — **tap a seat on the seating chart → 
 - **Browse by prefecture** — the venue tree on the left is grouped and collapsible by Japanese administrative divisions; Fuse.js client-side fuzzy search matches Chinese / Japanese / romaji aliases.
 - **Seating-chart markers** — view seat markers placed by other users on the venue's official seating chart (supports multi-layer / multi-zone tag switching); adjacent markers auto-cluster and show a count.
 - **Real-view Lightbox** — click a marker to see that seat's actual photo + seat number / text description; the masonry feed below shows every submission for that venue.
-- **Venue comments and ratings** — a quiet entry in the venue title area shows the average / rating count and opens a right drawer: anonymous 1–5-star rating on top (rating again changes your score), giscus comments below, strictly mapped to `venue:<id>` and shared across locales and seating-chart tabs.
+- **Venue comments and ratings** — a quiet entry in the venue title area shows the overall score / rating count and opens a right drawer: anonymous four-dimension 1–5-star ratings on top (view, sound, amenities, transit; rating again changes your scores), giscus comments below, strictly mapped to `venue:<id>` and shared across locales and seating-chart tabs.
 - **Registration-free uploads** — mark (with an optional full-screen zoom mode for precise placement) → pick image → compress to WebP client-side (EXIF stripped) → two-stage HMAC-ticket submission; in-line guidance nudges you through unfinished steps, with IP rate limiting + Turnstile guarding the whole flow.
 - **Multilingual i18n** — `/zh` `/ja` `/en` `/ko` four-prefix routing; the bare root `/` auto-redirects by `Accept-Language` (zh / ja are equal tracks, while en / ko are an accessibility translation layer).
 - **Venue crowdsourcing** — +1 a venue in the in-site "venues you want to see" staging area (public vote count + daily rate limit + name dedup), or submit venue JSON directly via a GitHub PR.
@@ -89,7 +89,7 @@ The core experience is just two steps — **tap a seat on the seating chart → 
 | Image storage | **Cloudflare R2** (`BUCKET`) | **direct binding writes**, not presigned URLs |
 | Bot defense | **Cloudflare Turnstile** | two steps: frontend token → backend siteverify |
 | Comments | **giscus** + `@giscus/react` | GitHub Discussions-backed comments; the drawer lazy-loads on first open and follows the site light / dark theme |
-| Anonymous ratings | **D1 aggregate table** + React island | 1–5-star ratings; `venue_id + ip_hash` dedupe, `venue_rating_agg` aggregate reads |
+| Anonymous ratings | **D1 aggregate table** + React island | Four-dimension 1–5-star ratings; `venue_id + ip_hash` dedupe, `venue_rating_agg` dimensional aggregate reads |
 | Image processing | `browser-image-compression` | long edge 1920px / WebP / EXIF stripped / ~500KB |
 | Lightbox | `yet-another-react-lightbox` v3 | |
 | Masonry | `react-photo-album` (masonry) | |
@@ -232,7 +232,7 @@ Soft delete: when a maintainer deletes a photo in `/admin`, D1 sets `deleted_at`
 
 The venue title area mounts the `VenueComments` island, which starts as a demoted entry chip (average / rating count / comments). `@giscus/react` is dynamically imported only when the drawer first opens; closing the drawer hides it instead of unmounting it, so the giscus iframe is not reloaded on reopen. giscus uses `mapping="specific"` + `term="venue:<id>"`, so the same venue shares one GitHub Discussions thread across locale paths and seating-chart tabs. Its theme follows the site's `html.dark` class instead of the system theme. If `PUBLIC_GISCUS_CATEGORY_ID` or another required value is empty, the comments block renders a "not available yet" state and loads no third-party script or iframe.
 
-Anonymous ratings go through `POST /api/rating`, accepting only 1–5 stars and a static venue `venue.id`. They intentionally skip Turnstile (a single click should not trigger a challenge), but still use `TURNSTILE_SECRET_KEY` as the IP-hash salt. D1 stores one `venue_ratings` row per `venue_id + ip_hash`; rating again changes that score instead of adding another vote. `venue_rating_agg` stores the count / sum aggregate, and row writes plus aggregate updates happen in one `db.batch`. Venue SSR reads only that aggregate row and fails soft to an empty rating state if the read fails. KV limits only the number of new venues rated per day; changing an existing score does not consume quota.
+Anonymous ratings go through `POST /api/rating`, accepting only a static venue `venue.id` and a complete four-dimension 1–5-star score set: view, sound, amenities, and transit. They intentionally skip Turnstile (a rating should not trigger a challenge), but still use `TURNSTILE_SECRET_KEY` as the IP-hash salt. D1 stores one `venue_ratings` row per `venue_id + ip_hash`; rating again changes those four scores instead of adding another vote. `venue_rating_agg` stores the dimensional count / sum aggregate, and row writes plus aggregate updates happen in one `db.batch`. Venue SSR reads only that aggregate row and fails soft to an empty rating state if the read fails. KV limits only the number of new venues rated per day; changing an existing score does not consume quota.
 
 ### Key Implementation Trade-offs
 
@@ -247,7 +247,7 @@ Anonymous ratings go through `POST /api/rating`, accepting only 1–5 stars and 
 6. **ULID self-implemented** (`crypto.getRandomValues`), not the `ulid` package.
 7. The R2 binding is named **`BUCKET`**, the rate-limit KV is **`RATE_LIMIT`**, plus a **`SESSION`** KV (required by the adapter's auto-enabled session API; SeatView has no account system and doesn't actually write sessions, but the binding must resolve); admin uses **Cloudflare Access** (the `Cf-Access-Authenticated-User-Email` header), mocked locally via `DEV_ADMIN_EMAIL` in `.dev.vars`.
 8. **giscus comments are optional public config**: when `PUBLIC_GISCUS_*` is missing, no third-party resources load; once configured, comments map to GitHub Discussions by `venue:<id>`.
-9. **Venue ratings are anonymous D1 aggregates**: `venue_ratings` stores the current score for each `venue_id + ip_hash`, and `venue_rating_agg` stores display aggregates; this is not GitHub reactions or social likes.
+9. **Venue ratings are anonymous D1 aggregates**: `venue_ratings` stores the current four scores for each `venue_id + ip_hash`, and `venue_rating_agg` stores display aggregates; this is not GitHub reactions or social likes.
 
 </details>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,7 +67,7 @@
 - **都道府県別ブラウズ** —— 左側の会場ツリーは日本の行政区画でグループ化・折りたたみ可能。Fuse.js のクライアントサイドあいまい検索で、中国語 / 日本語 / ローマ字のエイリアスもヒットします。
 - **座席表マーキング** —— 会場公式の座席表（複数レイヤー / 複数エリアの tag 切り替え対応）上で、他ユーザーがマークした座席ポイントを表示。隣接するポイントは自動で集約し件数を表示します。
 - **リアルビュー Lightbox** —— マーカーをクリックすると、その席の実写 + 座席番号 / テキスト説明を表示。下部のウォーターフォールでその会場の全投稿を表示します。
-- **会場コメントと評価** —— 会場タイトル付近の控えめな入口に平均点 / 評価数を表示し、右側のドロワーを開きます。上部は匿名 1〜5 星評価（再評価はスコア変更）、下部は `venue:<id>` に厳密マッピングされた giscus コメントで、言語パスや座席表タブをまたいで同じ議論を共有します。
+- **会場コメントと評価** —— 会場タイトル付近の控えめな入口に総合点 / 評価数を表示し、右側のドロワーを開きます。上部は匿名4項目の 1〜5 星評価（見やすさ、音響、周辺の便利さ、アクセス。再評価はスコア変更）、下部は `venue:<id>` に厳密マッピングされた giscus コメントで、言語パスや座席表タブをまたいで同じ議論を共有します。
 - **登録不要の投稿** —— マーク（全画面ズームで精密に配置するモードあり）→ 画像選択 → クライアント側で WebP に圧縮（EXIF 除去）→ HMAC ticket の二段階コミット。未完了のステップはインライン案内で誘導し、全工程で IP レート制限 + Turnstile による不正対策。
 - **多言語 i18n** —— `/zh` `/ja` `/en` `/ko` の 4 プレフィックスルーティング、ルート直下 `/` は `Accept-Language` で自動リダイレクト（`zh` / `ja` は対等な二軸、`en` / `ko` はアクセシビリティのための翻訳レイヤー）。
 - **会場のクラウドソーシング** —— サイト内「見たい会場」一時置き場で +1（公開票数 + 日次レート制限 + 同名の重複排除）、または GitHub PR で会場 JSON を直接投稿。
@@ -89,7 +89,7 @@
 | 画像ストレージ | **Cloudflare R2**（`BUCKET`） | **バインディング直接書き込み**、presigned URL ではない |
 | ボット対策 | **Cloudflare Turnstile** | 二段階：フロントエンド token → バックエンド siteverify |
 | コメント | **giscus** + `@giscus/react` | GitHub Discussions を使用。コメントドロワーは初回オープン時だけ遅延ロードし、サイトのライト / ダークテーマに追従 |
-| 匿名評価 | **D1 集約テーブル** + React island | 1〜5 星評価。`venue_id + ip_hash` で重複排除し、`venue_rating_agg` から集約を読み取り |
+| 匿名評価 | **D1 集約テーブル** + React island | 4項目の 1〜5 星評価。`venue_id + ip_hash` で重複排除し、`venue_rating_agg` から次元別集約を読み取り |
 | 画像処理 | `browser-image-compression` | 長辺 1920px / WebP / EXIF 除去 / 約 500KB |
 | Lightbox | `yet-another-react-lightbox` v3 | |
 | ウォーターフォール | `react-photo-album`（masonry） | |
@@ -232,7 +232,7 @@ presigned URL によるクライアント直接アップロードではなく、
 
 会場タイトル付近には `VenueComments` island がマウントされ、初期状態では控えめな入口（平均点 / 評価数 / コメント）だけを表示します。`@giscus/react` はドロワーを初めて開いたときだけ動的 import されます。閉じるときはアンマウントせず非表示にするため、再オープン時に giscus iframe が再読み込みされません。giscus は `mapping="specific"` + `term="venue:<id>"` を使うので、同じ会場は言語パスや座席表タブをまたいで 1 つの GitHub Discussions スレッドを共有します。テーマはシステムテーマではなく、サイトの `html.dark` クラスに追従します。`PUBLIC_GISCUS_CATEGORY_ID` など必須値が空の場合、コメント欄は「まだ利用できません」状態だけを表示し、第三者 script / iframe は読み込みません。
 
-匿名評価は `POST /api/rating` を通り、静的な `venue.id` と 1〜5 星のみを受け付けます。単発クリックで challenge を出さないため Turnstile は使いませんが、`TURNSTILE_SECRET_KEY` は IP-hash salt として使います。D1 では `venue_id + ip_hash` ごとに `venue_ratings` を 1 行だけ保存し、再評価は新規票ではなくスコア変更になります。`venue_rating_agg` は count / sum の集約を保持し、評価行と集約の更新は 1 つの `db.batch` で行います。会場ページ SSR はこの集約行だけを読み、失敗しても空の評価状態へ静かにフォールバックします。KV は「1 日に新規評価した異なる会場数」だけを制限し、既存スコアの変更では消費しません。
+匿名評価は `POST /api/rating` を通り、静的な `venue.id` と完全な4項目 1〜5 星評価（見やすさ、音響、周辺の便利さ、アクセス）のみを受け付けます。単発評価で challenge を出さないため Turnstile は使いませんが、`TURNSTILE_SECRET_KEY` は IP-hash salt として使います。D1 では `venue_id + ip_hash` ごとに `venue_ratings` を 1 行だけ保存し、再評価は新規票ではなく4項目スコアの変更になります。`venue_rating_agg` は次元別の count / sum 集約を保持し、評価行と集約の更新は 1 つの `db.batch` で行います。会場ページ SSR はこの集約行だけを読み、失敗しても空の評価状態へ静かにフォールバックします。KV は「1 日に新規評価した異なる会場数」だけを制限し、既存スコアの変更では消費しません。
 
 ### 主要な実装上のトレードオフ
 
@@ -247,7 +247,7 @@ presigned URL によるクライアント直接アップロードではなく、
 6. **ULID は自前実装**（`crypto.getRandomValues`）で、`ulid` パッケージは不使用。
 7. R2 バインディング名は **`BUCKET`**、レート制限 KV は **`RATE_LIMIT`**、さらに **`SESSION`** KV があります（アダプターが自動で有効化する session API に必要。SeatView はアカウントシステムを持たず session を実際には書きませんが、バインディングは解決可能である必要があります）。admin は **Cloudflare Access**（`Cf-Access-Authenticated-User-Email` ヘッダー）を使用し、ローカルでは `.dev.vars` の `DEV_ADMIN_EMAIL` で mock します。
 8. **giscus コメントは任意の公開設定**です。`PUBLIC_GISCUS_*` が欠けている場合は第三者リソースを読み込まず、設定済みなら `venue:<id>` で GitHub Discussions に紐づけます。
-9. **会場評価は匿名の D1 集約**です。`venue_ratings` は各 `venue_id + ip_hash` の現在スコアを保存し、`venue_rating_agg` は表示用の集約を保存します。GitHub reaction やソーシャルな「いいね」ではありません。
+9. **会場評価は匿名の D1 集約**です。`venue_ratings` は各 `venue_id + ip_hash` の現在4項目スコアを保存し、`venue_rating_agg` は表示用の集約を保存します。GitHub reaction やソーシャルな「いいね」ではありません。
 
 </details>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -67,7 +67,7 @@
 - **광역자치단체별 탐색** —— 왼쪽 공연장 트리는 일본 행정 구역으로 그룹화되어 접을 수 있습니다. Fuse.js 클라이언트 측 퍼지 검색으로 중국어 / 일본어 / 로마자 별칭까지 매칭됩니다.
 - **좌석도 마킹** —— 공연장 공식 좌석도(다중 레이어 / 다중 구역 tag 전환 지원) 위에서 다른 사용자가 표시한 좌석 포인트를 확인하고, 인접한 포인트는 자동으로 묶여 개수가 표시됩니다.
 - **실제 시야 Lightbox** —— 마커를 클릭하면 그 좌석의 실사 사진 + 좌석 번호 / 텍스트 설명을 볼 수 있습니다. 아래의 워터폴(masonry)에는 해당 공연장의 모든 투고가 표시됩니다.
-- **공연장 댓글과 평점** —— 공연장 제목 영역의 조용한 진입점에 평균 점수 / 평점 수를 표시하고 오른쪽 드로어를 엽니다. 위쪽은 익명 1~5점 별점(다시 평가하면 점수 변경), 아래쪽은 `venue:<id>` 에 엄격하게 매핑된 giscus 댓글이며, 언어 경로와 좌석도 탭을 넘어 같은 토론을 공유합니다.
+- **공연장 댓글과 평점** —— 공연장 제목 영역의 조용한 진입점에 종합 점수 / 평점 수를 표시하고 오른쪽 드로어를 엽니다. 위쪽은 익명 네 항목 1~5점 별점(시야, 소리, 주변 편의, 교통. 다시 평가하면 점수 변경), 아래쪽은 `venue:<id>` 에 엄격하게 매핑된 giscus 댓글이며, 언어 경로와 좌석도 탭을 넘어 같은 토론을 공유합니다.
 - **회원 가입 없는 업로드** —— 마킹(전체 화면 줌으로 정밀하게 배치하는 모드 제공) → 이미지 선택 → 클라이언트 측에서 WebP 로 압축(EXIF 제거) → HMAC ticket 의 2단계 제출. 완료되지 않은 단계는 인라인 안내로 유도하며, 전 과정에 IP 요청 빈도 제한 + Turnstile 남용 방지가 적용됩니다.
 - **다국어 i18n** —— `/zh` `/ja` `/en` `/ko` 4개 프리픽스 라우팅, 루트 직하 `/` 는 `Accept-Language` 에 따라 자동 리다이렉트(`zh` / `ja` 는 대등한 두 축이며, `en` / `ko` 는 접근성을 위한 번역 레이어).
 - **공연장 크라우드소싱** —— 사이트 내 「보고 싶은 공연장」 임시 보관 영역에서 +1(공개 득표 수 + 일일 요청 제한 + 동명 중복 제거)하거나, GitHub PR 로 공연장 JSON 을 직접 제출할 수 있습니다.
@@ -89,7 +89,7 @@
 | 이미지 저장 | **Cloudflare R2**(`BUCKET`) | **바인딩 직접 쓰기**, presigned URL 이 아님 |
 | 봇 방어 | **Cloudflare Turnstile** | 2단계: 프런트엔드 token → 백엔드 siteverify |
 | 댓글 | **giscus** + `@giscus/react` | GitHub Discussions 기반 댓글. 댓글 드로어는 첫 오픈 때만 지연 로드하며 사이트의 라이트 / 다크 테마를 따름 |
-| 익명 평점 | **D1 집계 테이블** + React island | 1~5점 별점. `venue_id + ip_hash` 로 중복 제거하고 `venue_rating_agg` 에서 집계 읽기 |
+| 익명 평점 | **D1 집계 테이블** + React island | 네 항목 1~5점 별점. `venue_id + ip_hash` 로 중복 제거하고 `venue_rating_agg` 에서 항목별 집계 읽기 |
 | 이미지 처리 | `browser-image-compression` | 긴 변 1920px / WebP / EXIF 제거 / 약 500KB |
 | Lightbox | `yet-another-react-lightbox` v3 | |
 | 워터폴 | `react-photo-album`(masonry) | |
@@ -232,7 +232,7 @@ presigned URL 을 통한 클라이언트 직접 업로드가 아니라 **sign + 
 
 공연장 제목 영역에는 `VenueComments` island 가 마운트되며, 처음에는 조용한 진입 칩(평균 점수 / 평점 수 / 댓글)만 표시됩니다. `@giscus/react` 는 드로어를 처음 열 때만 동적으로 import 됩니다. 닫을 때는 언마운트하지 않고 숨기기 때문에 다시 열어도 giscus iframe 이 재로딩되지 않습니다. giscus 는 `mapping="specific"` + `term="venue:<id>"` 를 사용하므로 같은 공연장은 언어 경로와 좌석도 탭을 넘어 하나의 GitHub Discussions 스레드를 공유합니다. 테마는 시스템 테마가 아니라 사이트의 `html.dark` 클래스에 따릅니다. `PUBLIC_GISCUS_CATEGORY_ID` 같은 필수 값이 비어 있으면 댓글 영역은 “아직 사용할 수 없음” 상태만 표시하고 서드파티 script / iframe 을 불러오지 않습니다.
 
-익명 평점은 `POST /api/rating` 을 거치며, 정적 `venue.id` 와 1~5점만 받습니다. 단일 클릭에 challenge 를 띄우지 않기 위해 Turnstile 은 사용하지 않지만, `TURNSTILE_SECRET_KEY` 는 IP-hash salt 로 사용합니다. D1 은 `venue_id + ip_hash` 마다 `venue_ratings` 한 행만 저장하며, 다시 평가하면 새 표가 아니라 점수가 변경됩니다. `venue_rating_agg` 는 count / sum 집계를 저장하고, 평점 행과 집계 업데이트는 하나의 `db.batch` 에서 처리됩니다. 공연장 페이지 SSR 은 이 집계 행만 읽으며, 실패해도 빈 평점 상태로 조용히 폴백합니다. KV 는 “하루에 새로 평점을 남긴 서로 다른 공연장 수”만 제한하고, 기존 점수 변경에는 할당량을 쓰지 않습니다.
+익명 평점은 `POST /api/rating` 을 거치며, 정적 `venue.id` 와 완전한 네 항목 1~5점 점수(시야, 소리, 주변 편의, 교통)만 받습니다. 단일 평가에 challenge 를 띄우지 않기 위해 Turnstile 은 사용하지 않지만, `TURNSTILE_SECRET_KEY` 는 IP-hash salt 로 사용합니다. D1 은 `venue_id + ip_hash` 마다 `venue_ratings` 한 행만 저장하며, 다시 평가하면 새 표가 아니라 네 항목 점수가 변경됩니다. `venue_rating_agg` 는 항목별 count / sum 집계를 저장하고, 평점 행과 집계 업데이트는 하나의 `db.batch` 에서 처리됩니다. 공연장 페이지 SSR 은 이 집계 행만 읽으며, 실패해도 빈 평점 상태로 조용히 폴백합니다. KV 는 “하루에 새로 평점을 남긴 서로 다른 공연장 수”만 제한하고, 기존 점수 변경에는 할당량을 쓰지 않습니다.
 
 ### 핵심 구현 선택
 
@@ -247,7 +247,7 @@ presigned URL 을 통한 클라이언트 직접 업로드가 아니라 **sign + 
 6. **ULID 자체 구현**(`crypto.getRandomValues`)으로, `ulid` 패키지는 사용하지 않습니다.
 7. R2 바인딩 이름은 **`BUCKET`**, 요청 빈도 제한 KV 는 **`RATE_LIMIT`**, 그리고 **`SESSION`** KV 가 있습니다(어댑터가 자동으로 활성화하는 session API 에 필요. SeatView 는 계정 시스템이 없어 session 을 실제로 쓰지 않지만, 바인딩은 해석 가능해야 합니다). admin 은 **Cloudflare Access**(`Cf-Access-Authenticated-User-Email` 헤더)를 사용하며, 로컬에서는 `.dev.vars` 의 `DEV_ADMIN_EMAIL` 로 mock 합니다.
 8. **giscus 댓글은 선택적 공개 설정**입니다. `PUBLIC_GISCUS_*` 가 없으면 서드파티 리소스를 불러오지 않고, 설정되어 있으면 `venue:<id>` 로 GitHub Discussions 에 연결합니다.
-9. **공연장 평점은 익명 D1 집계**입니다. `venue_ratings` 는 각 `venue_id + ip_hash` 의 현재 점수를 저장하고, `venue_rating_agg` 는 표시용 집계를 저장합니다. GitHub reaction 이나 소셜 “좋아요”가 아닙니다.
+9. **공연장 평점은 익명 D1 집계**입니다. `venue_ratings` 는 각 `venue_id + ip_hash` 의 현재 네 항목 점수를 저장하고, `venue_rating_agg` 는 표시용 집계를 저장합니다. GitHub reaction 이나 소셜 “좋아요”가 아닙니다.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 - **按都道府县浏览** —— 左侧场馆树按日本行政区划分组、可折叠；Fuse.js 客户端模糊搜索，中文 / 日文 / 罗马字别名都能命中。
 - **坐席图标注** —— 在场馆官方坐席图（支持多层 / 多分区 tag 切换）上查看其他用户标注的座位点，相邻点自动聚合并显示数量。
 - **真实视角 Lightbox** —— 点标注点即可查看该座位的实拍照片 + 座位号 / 文字描述；下方瀑布流展示该场馆的全部投稿。
-- **场馆评论与评分** —— 场馆页标题区的轻量入口显示平均分 / 评分数并打开右侧抽屉：上方是匿名 1–5 星评分（再次评分会改分），下方是按 `venue:<id>` 严格映射的 giscus 评论，跨语言与子坐席图共享同一讨论。
+- **场馆评论与评分** —— 场馆页标题区的轻量入口显示综合分 / 评分数并打开右侧抽屉：上方是匿名四项 1–5 星评分（视野、声音、周边便利、交通便利，再次评分会改分），下方是按 `venue:<id>` 严格映射的 giscus 评论，跨语言与子坐席图共享同一讨论。
 - **免注册上传** —— 标点（可进全屏放大精修）→ 选图 → 客户端压成 WebP（去 EXIF）→ HMAC ticket 两段式提交；未完成步骤有行内引导，全程 IP 限频 + Turnstile 防滥用。
 - **多语 i18n** —— `/zh` `/ja` `/en` `/ko` 四前缀路由，裸根 `/` 按 `Accept-Language` 自动重定向（`zh`/`ja` 等价双轨，`en`/`ko` 为可达性翻译层）。
 - **场馆众包** —— 站内「想看的场馆」暂存区可 +1 附议（公开票数 + 每日限流 + 同名去重），或通过 GitHub PR 直接提交场馆 JSON。
@@ -89,7 +89,7 @@
 | 图片存储 | **Cloudflare R2**（`BUCKET`） | **绑定直写**，不是 presigned URL |
 | 防机器人 | **Cloudflare Turnstile** | 两步：前端 token → 后端 siteverify |
 | 评论 | **giscus** + `@giscus/react` | GitHub Discussions 承载；评论抽屉首次打开才懒加载，主题跟随站点亮 / 暗模式 |
-| 匿名评分 | **D1 聚合表** + React island | 1–5 星评分；`venue_id + ip_hash` 去重，`venue_rating_agg` 读聚合 |
+| 匿名评分 | **D1 聚合表** + React island | 四项 1–5 星评分；`venue_id + ip_hash` 去重，`venue_rating_agg` 读四维聚合 |
 | 图片处理 | `browser-image-compression` | 长边 1920px / WebP / 去 EXIF / ~500KB |
 | Lightbox | `yet-another-react-lightbox` v3 | |
 | 瀑布流 | `react-photo-album`（masonry） | |
@@ -232,7 +232,7 @@ npm run deploy
 
 场馆页标题区挂载 `VenueComments` island，默认只显示一个降权的小入口（平均分 / 评分数 / 评论）。首次打开抽屉时才动态加载 `@giscus/react`；关闭抽屉时隐藏而不是卸载，因此 giscus iframe 不会反复重载。giscus 使用 `mapping="specific"` + `term="venue:<id>"`，同一场馆在不同语言路径、不同子坐席图 tab 下共享同一条 GitHub Discussions 讨论；主题跟随站点的 `html.dark` 类，而不是系统主题。若 `PUBLIC_GISCUS_CATEGORY_ID` 等配置为空，评论区只显示“暂未开放”状态，不加载任何第三方脚本或 iframe。
 
-匿名评分走 `POST /api/rating`，只接受 1–5 星与静态场馆 `venue.id`。它不跑 Turnstile（单次点击不应弹挑战），但仍使用 `TURNSTILE_SECRET_KEY` 作为 IP-hash salt；D1 中 `venue_ratings` 通过 `venue_id + ip_hash` 唯一索引去重，同一人再次评分会改分而不是新增一票。`venue_rating_agg` 保存 count / sum 聚合，写入与聚合更新在同一个 `db.batch` 中完成；场馆页 SSR 只读这一行聚合，失败时降级为空评分，不影响页面打开。KV 只限制“每天新增评分的不同场馆数”，改已有分数不消耗配额。
+匿名评分走 `POST /api/rating`，只接受静态场馆 `venue.id` 与完整四项 1–5 星评分：视野、声音、周边便利、交通便利。它不跑 Turnstile（单次评分不应弹挑战），但仍使用 `TURNSTILE_SECRET_KEY` 作为 IP-hash salt；D1 中 `venue_ratings` 通过 `venue_id + ip_hash` 唯一索引去重，同一人再次评分会改四项分数而不是新增一票。`venue_rating_agg` 保存四维 count / sum 聚合，写入与聚合更新在同一个 `db.batch` 中完成；场馆页 SSR 只读这一行聚合，失败时降级为空评分，不影响页面打开。KV 只限制“每天新增评分的不同场馆数”，改已有分数不消耗配额。
 
 ### 关键实现取舍
 
@@ -247,7 +247,7 @@ npm run deploy
 6. **ULID 自实现**（`crypto.getRandomValues`），不用 `ulid` 包。
 7. R2 绑定名是 **`BUCKET`**、限频 KV 是 **`RATE_LIMIT`**，另有 **`SESSION`** KV（适配器自动启用 session API 所需，SeatView 无账号系统、不实际写 session，但绑定需可解析）；admin 用 **Cloudflare Access**（`Cf-Access-Authenticated-User-Email` 头），本地用 `.dev.vars` 的 `DEV_ADMIN_EMAIL` mock。
 8. **giscus 评论是可选公共配置**：缺 `PUBLIC_GISCUS_*` 时不加载第三方资源；配置齐全后，评论按 `venue:<id>` 映射到 GitHub Discussions。
-9. **场馆评分是匿名 D1 聚合**：`venue_ratings` 存每个 `venue_id + ip_hash` 的当前分数，`venue_rating_agg` 存展示聚合；不是 GitHub reaction，也不是社交点赞。
+9. **场馆评分是匿名 D1 聚合**：`venue_ratings` 存每个 `venue_id + ip_hash` 的当前四项分数，`venue_rating_agg` 存展示聚合；不是 GitHub reaction，也不是社交点赞。
 
 </details>
 

--- a/migrations/0006_split_venue_rating_dimensions.sql
+++ b/migrations/0006_split_venue_rating_dimensions.sql
@@ -1,0 +1,9 @@
+ALTER TABLE `venue_ratings` ADD `view_score` integer;
+ALTER TABLE `venue_ratings` ADD `sound_score` integer;
+ALTER TABLE `venue_ratings` ADD `amenities_score` integer;
+ALTER TABLE `venue_ratings` ADD `transit_score` integer;
+ALTER TABLE `venue_rating_agg` ADD `dimension_rating_count` integer DEFAULT 0 NOT NULL;
+ALTER TABLE `venue_rating_agg` ADD `view_rating_sum` integer DEFAULT 0 NOT NULL;
+ALTER TABLE `venue_rating_agg` ADD `sound_rating_sum` integer DEFAULT 0 NOT NULL;
+ALTER TABLE `venue_rating_agg` ADD `amenities_rating_sum` integer DEFAULT 0 NOT NULL;
+ALTER TABLE `venue_rating_agg` ADD `transit_rating_sum` integer DEFAULT 0 NOT NULL;

--- a/migrations/meta/0006_snapshot.json
+++ b/migrations/meta/0006_snapshot.json
@@ -1,0 +1,516 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "baa3cc09-230e-46ff-917a-810fd3cef031",
+  "prevId": "6508f23a-6438-49b1-9c49-4b9b6b7a69a4",
+  "tables": {
+    "photo_correction_requests": {
+      "name": "photo_correction_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "photo_id": {
+          "name": "photo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_seat_label": {
+          "name": "current_seat_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_seat_label": {
+          "name": "requested_seat_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_dedup_key": {
+          "name": "active_dedup_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_photo_corrections_active_dedup": {
+          "name": "idx_photo_corrections_active_dedup",
+          "columns": [
+            "active_dedup_key"
+          ],
+          "isUnique": true
+        },
+        "idx_photo_corrections_pending": {
+          "name": "idx_photo_corrections_pending",
+          "columns": [
+            "processed_at",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_photo_corrections_photo": {
+          "name": "idx_photo_corrections_photo",
+          "columns": [
+            "photo_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "photos": {
+      "name": "photos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sub_map_id": {
+          "name": "sub_map_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "x_percent": {
+          "name": "x_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "y_percent": {
+          "name": "y_percent",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_key": {
+          "name": "image_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seat_label": {
+          "name": "seat_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performance_date": {
+          "name": "performance_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_photos_venue": {
+          "name": "idx_photos_venue",
+          "columns": [
+            "venue_id",
+            "sub_map_id",
+            "deleted_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staging_venues": {
+      "name": "staging_venues",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "staging_votes": {
+      "name": "staging_votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_staging_votes_unique": {
+          "name": "idx_staging_votes_unique",
+          "columns": [
+            "venue_id",
+            "ip_hash"
+          ],
+          "isUnique": true
+        },
+        "idx_staging_votes_ip": {
+          "name": "idx_staging_votes_ip",
+          "columns": [
+            "ip_hash",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "venue_rating_agg": {
+      "name": "venue_rating_agg",
+      "columns": {
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_count": {
+          "name": "rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "rating_sum": {
+          "name": "rating_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dimension_rating_count": {
+          "name": "dimension_rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "view_rating_sum": {
+          "name": "view_rating_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sound_rating_sum": {
+          "name": "sound_rating_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "amenities_rating_sum": {
+          "name": "amenities_rating_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "transit_rating_sum": {
+          "name": "transit_rating_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "venue_ratings": {
+      "name": "venue_ratings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "view_score": {
+          "name": "view_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sound_score": {
+          "name": "sound_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amenities_score": {
+          "name": "amenities_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transit_score": {
+          "name": "transit_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_venue_ratings_dedup": {
+          "name": "idx_venue_ratings_dedup",
+          "columns": [
+            "venue_id",
+            "ip_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1781133934814,
       "tag": "0005_venue_ratings",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1781801157645,
+      "tag": "0006_split_venue_rating_dimensions",
+      "breakpoints": true
     }
   ]
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -223,10 +223,21 @@ const en: Messages = {
     title: "Comments & ratings",
     close: "Close",
     ratingTitle: "Rate this venue",
-    starLabel: "Rate {n} out of 5",
+    overallLabel: "Overall",
+    dimensions: {
+      view: "View",
+      sound: "Sound",
+      amenities: "Amenities",
+      transit: "Transit",
+    },
+    dimensionGroupLabel: "Rate {dimension}",
+    starLabel: "Rate {dimension} {n} out of 5",
     ratingSummary: "Average {avg} · {count} ratings",
     ratingEmpty: "No ratings yet. Want to be the first?",
-    yourScore: "You rated {score}. Tap another star to change it.",
+    yourRatingTitle: "Your rating",
+    ratingIncomplete: "Choose all four dimensions to save.",
+    ratingSave: "Save rating",
+    ratingSaving: "Saving…",
     ratingNote:
       "No sign-in needed to rate. For de-duplication we keep only a salted hash of your IP, never the raw IP.",
     ratingSaved: "Saved.",
@@ -271,7 +282,7 @@ const en: Messages = {
       },
       {
         heading: "Comments and ratings",
-        body: "Venue comments are provided by the third-party service giscus, loaded as an embedded frame, and stored in the Discussions of our public GitHub repository. Posting a comment requires signing in to GitHub and authorizing giscus; that step is governed by the GitHub and giscus privacy policies. Reading needs no account. Venue ratings need no sign-in either: as with vote de-duplication, we keep only a salted hash of your IP, never the raw IP.",
+        body: "Venue comments are provided by the third-party service giscus, loaded as an embedded frame, and stored in the Discussions of our public GitHub repository. Posting a comment requires signing in to GitHub and authorizing giscus; that step is governed by the GitHub and giscus privacy policies. Reading needs no account. Four-dimension venue ratings need no sign-in either: as with vote de-duplication, we keep only a salted hash of your IP, never the raw IP.",
       },
       {
         heading: "Local storage",
@@ -300,7 +311,7 @@ const en: Messages = {
       },
       {
         heading: "Comments and ratings",
-        body: "Venue comments are stored in GitHub Discussions and are subject to GitHub's terms of service and community guidelines. We may delete, minimize, or lock inappropriate comments and block the accounts involved. Anonymous ratings are for reference only; we may adjust or remove rating data if manipulation is found.",
+        body: "Venue comments are stored in GitHub Discussions and are subject to GitHub's terms of service and community guidelines. We may delete, minimize, or lock inappropriate comments and block the accounts involved. Anonymous four-dimension ratings are for reference only; we may adjust or remove rating data if manipulation is found.",
       },
       {
         heading: "Disclaimer",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -213,11 +213,21 @@ const ja: Messages = {
     title: "コメントと評価",
     close: "閉じる",
     ratingTitle: "この会場を評価する",
-    starLabel: "星 {n} つ",
+    overallLabel: "総合",
+    dimensions: {
+      view: "見やすさ",
+      sound: "音響",
+      amenities: "周辺の便利さ",
+      transit: "アクセス",
+    },
+    dimensionGroupLabel: "{dimension}を評価",
+    starLabel: "{dimension} 星 {n} つ",
     ratingSummary: "平均 {avg} · {count} 件の評価",
     ratingEmpty: "まだ評価がありません。最初の一人に、あなたが。",
-    yourScore:
-      "あなたの評価は星 {score} つ。他の星をタップすると変更できます。",
+    yourRatingTitle: "あなたの評価",
+    ratingIncomplete: "4項目すべてを選ぶと保存できます。",
+    ratingSave: "評価を保存",
+    ratingSaving: "保存中…",
     ratingNote:
       "評価にログインは不要です。重複防止のため、ソルト付きでハッシュ化した IP のみを保存し、生の IP は保存しません。",
     ratingSaved: "記録しました。",
@@ -262,7 +272,7 @@ const ja: Messages = {
       },
       {
         heading: "コメントと評価",
-        body: "会場コメントは第三者サービス giscus を埋め込みで利用し、内容は公開 GitHub リポジトリの Discussions に保存されます。コメントの投稿には GitHub へのログインと giscus の認可が必要で、この処理には GitHub および giscus のプライバシーポリシーが適用されます。閲覧だけならログインは不要です。会場の評価にもログインは不要で、投票の重複防止と同じく、ソルト付きでハッシュ化した IP のみを保存し、生の IP は保存しません。",
+        body: "会場コメントは第三者サービス giscus を埋め込みで利用し、内容は公開 GitHub リポジトリの Discussions に保存されます。コメントの投稿には GitHub へのログインと giscus の認可が必要で、この処理には GitHub および giscus のプライバシーポリシーが適用されます。閲覧だけならログインは不要です。会場の4項目評価にもログインは不要で、投票の重複防止と同じく、ソルト付きでハッシュ化した IP のみを保存し、生の IP は保存しません。",
       },
       {
         heading: "ローカルストレージ",
@@ -291,7 +301,7 @@ const ja: Messages = {
       },
       {
         heading: "コメントと評価",
-        body: "会場コメントは GitHub Discussions に保存され、GitHub の利用規約とコミュニティガイドラインが適用されます。不適切なコメントは削除・非表示・ロックし、関連アカウントをブロックすることがあります。匿名の評価は参考情報であり、不正な操作を確認した場合は該当データを調整・削除することがあります。",
+        body: "会場コメントは GitHub Discussions に保存され、GitHub の利用規約とコミュニティガイドラインが適用されます。不適切なコメントは削除・非表示・ロックし、関連アカウントをブロックすることがあります。匿名の4項目評価は参考情報であり、不正な操作を確認した場合は該当データを調整・削除することがあります。",
       },
       {
         heading: "免責事項",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -220,10 +220,21 @@ const ko: Messages = {
     title: "댓글과 평점",
     close: "닫기",
     ratingTitle: "이 회장을 평가하기",
-    starLabel: "별 {n}개",
+    overallLabel: "종합",
+    dimensions: {
+      view: "시야",
+      sound: "소리",
+      amenities: "주변 편의",
+      transit: "교통",
+    },
+    dimensionGroupLabel: "{dimension} 평가",
+    starLabel: "{dimension} 별 {n}개",
     ratingSummary: "평균 {avg} · {count}명이 평가",
     ratingEmpty: "아직 평점이 없어요. 첫 번째가 되어 볼까요?",
-    yourScore: "별 {score}개를 주셨어요. 다른 별을 탭하면 바꿀 수 있어요.",
+    yourRatingTitle: "내 평가",
+    ratingIncomplete: "네 항목을 모두 선택하면 저장할 수 있어요.",
+    ratingSave: "평점 저장",
+    ratingSaving: "저장 중…",
     ratingNote:
       "평가에 로그인은 필요 없어요. 중복 방지를 위해 솔트 해시 처리한 IP만 저장하고 원본 IP는 저장하지 않아요.",
     ratingSaved: "기록했어요.",
@@ -268,7 +279,7 @@ const ko: Messages = {
       },
       {
         heading: "댓글과 평점",
-        body: "회장 댓글은 제3자 서비스 giscus를 통해 내장 프레임으로 제공되며, 내용은 공개 GitHub 저장소의 Discussions에 저장돼요. 댓글을 쓰려면 GitHub에 로그인하고 giscus를 승인해야 하며, 이 단계에는 GitHub와 giscus의 개인정보 처리방침이 적용돼요. 읽기만 할 때는 로그인이 필요 없어요. 회장 평점도 로그인 없이 가능하며, 투표 중복 방지와 마찬가지로 솔트 해시 처리한 IP만 저장하고 원본 IP는 저장하지 않아요.",
+        body: "회장 댓글은 제3자 서비스 giscus를 통해 내장 프레임으로 제공되며, 내용은 공개 GitHub 저장소의 Discussions에 저장돼요. 댓글을 쓰려면 GitHub에 로그인하고 giscus를 승인해야 하며, 이 단계에는 GitHub와 giscus의 개인정보 처리방침이 적용돼요. 읽기만 할 때는 로그인이 필요 없어요. 회장 네 항목 평점도 로그인 없이 가능하며, 투표 중복 방지와 마찬가지로 솔트 해시 처리한 IP만 저장하고 원본 IP는 저장하지 않아요.",
       },
       {
         heading: "로컬 저장소",
@@ -297,7 +308,7 @@ const ko: Messages = {
       },
       {
         heading: "댓글과 평점",
-        body: "회장 댓글은 GitHub Discussions에 저장되며 GitHub의 이용약관과 커뮤니티 가이드라인이 적용돼요. 부적절한 댓글은 삭제·접기·잠금 처리하고 관련 계정을 차단할 수 있어요. 익명 평점은 참고용이며, 조작이 확인되면 해당 데이터를 조정하거나 삭제할 수 있어요.",
+        body: "회장 댓글은 GitHub Discussions에 저장되며 GitHub의 이용약관과 커뮤니티 가이드라인이 적용돼요. 부적절한 댓글은 삭제·접기·잠금 처리하고 관련 계정을 차단할 수 있어요. 익명 네 항목 평점은 참고용이며, 조작이 확인되면 해당 데이터를 조정하거나 삭제할 수 있어요.",
       },
       {
         heading: "면책 조항",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -264,14 +264,29 @@ export interface Messages {
     close: string;
     /** Rating block heading. */
     ratingTitle: string;
-    /** Star button aria-label, `{n}` → 1..5. */
+    /** Overall score label. */
+    overallLabel: string;
+    /** Dimension labels. */
+    dimensions: {
+      view: string;
+      sound: string;
+      amenities: string;
+      transit: string;
+    };
+    /** Star group aria-label, `{dimension}` → localized dimension. */
+    dimensionGroupLabel: string;
+    /** Star button aria-label, `{dimension}` + `{n}` → 1..5. */
     starLabel: string;
     /** Aggregate line under the stars, `{avg}` + `{count}`. */
     ratingSummary: string;
     /** Zero ratings (gentle 缝隙时刻). */
     ratingEmpty: string;
-    /** Your current score line, `{score}`. */
-    yourScore: string;
+    /** Your rating block heading. */
+    yourRatingTitle: string;
+    /** Incomplete four-dimension selection prompt. */
+    ratingIncomplete: string;
+    ratingSave: string;
+    ratingSaving: string;
     /** Transparency one-liner: no login, salted IP hash only. */
     ratingNote: string;
     /** Inline saved confirmation. */
@@ -741,10 +756,21 @@ const zh: Messages = {
     title: "评论与评分",
     close: "关闭",
     ratingTitle: "给这个场馆打分",
-    starLabel: "{n} 星",
+    overallLabel: "综合",
+    dimensions: {
+      view: "视野",
+      sound: "声音",
+      amenities: "周边便利",
+      transit: "交通便利",
+    },
+    dimensionGroupLabel: "给{dimension}打分",
+    starLabel: "{dimension} {n} 星",
     ratingSummary: "平均 {avg} · {count} 人评分",
     ratingEmpty: "还没有人打分。第一个，由你来。",
-    yourScore: "你打了 {score} 星。点其他星可以改分。",
+    yourRatingTitle: "你的评分",
+    ratingIncomplete: "四项都选好后再保存。",
+    ratingSave: "保存评分",
+    ratingSaving: "保存中…",
     ratingNote:
       "打分无需登录。为了去重，我们只保存加盐哈希后的 IP，不存原 IP。",
     ratingSaved: "已记录。",
@@ -788,7 +814,7 @@ const zh: Messages = {
       },
       {
         heading: "评论与评分",
-        body: "场馆评论由第三方服务 giscus 提供，以内嵌页面加载，内容存储在我们公开 GitHub 仓库的 Discussions 中；发表评论需要登录 GitHub 并授权 giscus，这一环节受 GitHub 与 giscus 的隐私政策约束，仅浏览无需登录。场馆评分无需登录，与投票去重相同，我们只保存加盐哈希后的 IP，不存原 IP。",
+        body: "场馆评论由第三方服务 giscus 提供，以内嵌页面加载，内容存储在我们公开 GitHub 仓库的 Discussions 中；发表评论需要登录 GitHub 并授权 giscus，这一环节受 GitHub 与 giscus 的隐私政策约束，仅浏览无需登录。场馆四项评分无需登录，与投票去重相同，我们只保存加盐哈希后的 IP，不存原 IP。",
       },
       {
         heading: "本地存储",
@@ -817,7 +843,7 @@ const zh: Messages = {
       },
       {
         heading: "评论与评分",
-        body: "场馆评论存储在 GitHub Discussions 中，需遵守 GitHub 的服务条款与社区准则。我们可以删除、折叠或锁定不当评论，并屏蔽相关账号。匿名评分仅供参考，发现刷分时我们可以调整或清除相关数据。",
+        body: "场馆评论存储在 GitHub Discussions 中，需遵守 GitHub 的服务条款与社区准则。我们可以删除、折叠或锁定不当评论，并屏蔽相关账号。匿名四项评分仅供参考，发现刷分时我们可以调整或清除相关数据。",
       },
       {
         heading: "免责声明",

--- a/src/islands/VenueComments.tsx
+++ b/src/islands/VenueComments.tsx
@@ -36,9 +36,13 @@ import LoadFailure from "@/components/LoadFailure";
 import { fillTemplate } from "@/lib/format";
 import {
   applyOptimisticRating,
-  ratingAverage,
+  ratingDimensionAverage,
+  ratingOverallAverage,
+  RATING_DIMENSIONS,
   RATING_MAX,
   RATING_MIN,
+  type RatingDimension,
+  type RatingDimensionScores,
   type VenueRatingSummaryDto,
 } from "@/lib/venue-rating";
 import { RatingError, submitRating } from "@/lib/venue-rating-client";
@@ -83,6 +87,25 @@ const STARS = Array.from(
 const SHEET_ANIM_MS = 250;
 
 type RatingErrorKey = "limit" | "network" | "server";
+type RatingDraft = Partial<RatingDimensionScores>;
+
+function scoresEqual(
+  left: RatingDimensionScores | null,
+  right: RatingDimensionScores | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return RATING_DIMENSIONS.every(
+    (dimension) => left[dimension] === right[dimension],
+  );
+}
+
+function isCompleteDraft(draft: RatingDraft): draft is RatingDimensionScores {
+  return RATING_DIMENSIONS.every((dimension) => draft[dimension] !== undefined);
+}
+
+function draftFromSummary(summary: VenueRatingSummaryDto): RatingDraft {
+  return summary.yourScores ? { ...summary.yourScores } : {};
+}
 
 /**
  * The site's resolved light/dark theme, kept in sync with the `dark` class on
@@ -155,45 +178,59 @@ export default function VenueComments({
 
   // ── Rating state (optimistic with rollback) ────────────────────────────────
   const [summary, setSummary] = useState<VenueRatingSummaryDto>(initialRating);
+  const [draft, setDraft] = useState<RatingDraft>(() =>
+    draftFromSummary(initialRating),
+  );
   const [ratingPending, setRatingPending] = useState(false);
   const [ratingError, setRatingError] = useState<RatingErrorKey | null>(null);
   const [ratingSaved, setRatingSaved] = useState(false);
 
-  const rate = useCallback(
-    (score: number) => {
-      if (ratingPending || summary.yourScore === score) return;
-      const previous = summary;
-
-      setSummary(applyOptimisticRating(previous, score));
-      setRatingPending(true);
+  const setDraftScore = useCallback(
+    (dimension: RatingDimension, score: number) => {
+      if (ratingPending) return;
+      setDraft((current) => ({ ...current, [dimension]: score }));
       setRatingError(null);
       setRatingSaved(false);
-
-      submitRating(venueId, score)
-        .then((res) => {
-          // Reconcile to the authoritative aggregate.
-          setSummary({
-            count: res.ratingCount,
-            sum: res.ratingSum,
-            yourScore: res.yourScore,
-          });
-          setRatingSaved(true);
-        })
-        .catch((err: unknown) => {
-          setSummary(previous); // roll back the optimistic state
-          const code = err instanceof RatingError ? err.code : "server_error";
-          setRatingError(
-            code === "rate_limited_daily"
-              ? "limit"
-              : code === "network"
-                ? "network"
-                : "server",
-          );
-        })
-        .finally(() => setRatingPending(false));
     },
-    [ratingPending, summary, venueId],
+    [ratingPending],
   );
+
+  const saveRating = useCallback(() => {
+    if (ratingPending || !isCompleteDraft(draft)) return;
+    if (scoresEqual(summary.yourScores, draft)) return;
+    const previous = summary;
+    const previousDraft = draft;
+
+    setSummary(applyOptimisticRating(previous, draft));
+    setRatingPending(true);
+    setRatingError(null);
+    setRatingSaved(false);
+
+    submitRating(venueId, draft)
+      .then((res) => {
+        // Reconcile to the authoritative aggregate.
+        setSummary({
+          count: res.ratingCount,
+          sums: res.ratingSums,
+          yourScores: res.yourScores,
+        });
+        setDraft({ ...res.yourScores });
+        setRatingSaved(true);
+      })
+      .catch((err: unknown) => {
+        setSummary(previous); // roll back the optimistic state
+        setDraft(previousDraft);
+        const code = err instanceof RatingError ? err.code : "server_error";
+        setRatingError(
+          code === "rate_limited_daily"
+            ? "limit"
+            : code === "network"
+              ? "network"
+              : "server",
+        );
+      })
+      .finally(() => setRatingPending(false));
+  }, [draft, ratingPending, summary, venueId]);
 
   // ── giscus lazy load (first open only) ─────────────────────────────────────
   const [Giscus, setGiscus] = useState<ComponentType<GiscusProps> | null>(null);
@@ -225,7 +262,12 @@ export default function VenueComments({
   }, [open, loadGiscus]);
 
   // ── Derived display ────────────────────────────────────────────────────────
-  const average = ratingAverage(summary.count, summary.sum);
+  const average = ratingOverallAverage(summary);
+  const completeDraft = isCompleteDraft(draft) ? draft : null;
+  const saveDisabled =
+    ratingPending ||
+    completeDraft === null ||
+    scoresEqual(summary.yourScores, completeDraft);
   const ratingErrorText =
     ratingError === "limit"
       ? t.venueComments.ratingLimit
@@ -327,60 +369,134 @@ export default function VenueComments({
                 <h3 className="text-foreground text-sm font-medium">
                   {t.venueComments.ratingTitle}
                 </h3>
-                <div
-                  role="radiogroup"
-                  aria-label={t.venueComments.ratingTitle}
-                  className="mt-2 flex items-center"
-                >
-                  {STARS.map((n) => {
-                    const filled =
-                      summary.yourScore !== null && n <= summary.yourScore;
+                <div className="mt-3 border-border border-y py-3">
+                  <div className="flex items-baseline justify-between gap-4">
+                    <span className="text-muted-foreground text-xs">
+                      {t.venueComments.overallLabel}
+                    </span>
+                    <span className="text-foreground text-xl font-medium tabular-nums">
+                      {average !== null ? average.toFixed(1) : "—"}
+                    </span>
+                  </div>
+                  {average !== null ? (
+                    <p className="text-muted-foreground mt-1 text-[13px]">
+                      {fillTemplate(t.venueComments.ratingSummary, {
+                        avg: average.toFixed(1),
+                        count: String(summary.count),
+                      })}
+                    </p>
+                  ) : (
+                    <p className="text-muted-foreground mt-1 text-[13px]">
+                      {t.venueComments.ratingEmpty}
+                    </p>
+                  )}
+                </div>
+
+                <div className="mt-4 space-y-2">
+                  {RATING_DIMENSIONS.map((dimension) => {
+                    const dimensionAverage = ratingDimensionAverage(
+                      summary.count,
+                      summary.sums,
+                      dimension,
+                    );
                     return (
-                      <button
-                        key={n}
-                        type="button"
-                        role="radio"
-                        aria-checked={summary.yourScore === n}
-                        aria-label={fillTemplate(t.venueComments.starLabel, {
-                          n: String(n),
-                        })}
-                        disabled={ratingPending}
-                        onClick={() => rate(n)}
-                        className={cn(
-                          "grid size-11 place-items-center rounded-md",
-                          "transition-colors duration-150",
-                          "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
-                          "disabled:cursor-not-allowed disabled:opacity-60",
-                          filled
-                            ? "text-foreground"
-                            : "text-muted-foreground hover:text-foreground",
-                        )}
+                      <div
+                        key={dimension}
+                        className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 text-sm"
                       >
-                        <Star
-                          className="size-6"
-                          aria-hidden="true"
-                          fill={filled ? "currentColor" : "none"}
-                        />
-                      </button>
+                        <span className="text-foreground">
+                          {t.venueComments.dimensions[dimension]}
+                        </span>
+                        <span className="text-muted-foreground tabular-nums">
+                          {dimensionAverage !== null
+                            ? dimensionAverage.toFixed(1)
+                            : "—"}
+                        </span>
+                      </div>
                     );
                   })}
                 </div>
 
-                <p className="text-muted-foreground mt-2 text-[13px]">
-                  {average !== null
-                    ? fillTemplate(t.venueComments.ratingSummary, {
-                        avg: average.toFixed(1),
-                        count: String(summary.count),
-                      })
-                    : t.venueComments.ratingEmpty}
-                </p>
-                {summary.yourScore !== null ? (
-                  <p className="text-muted-foreground mt-1 text-[13px]">
-                    {fillTemplate(t.venueComments.yourScore, {
-                      score: String(summary.yourScore),
-                    })}
+                <h4 className="text-foreground mt-5 text-sm font-medium">
+                  {t.venueComments.yourRatingTitle}
+                </h4>
+                <div className="mt-2 space-y-3">
+                  {RATING_DIMENSIONS.map((dimension) => (
+                    <div
+                      key={dimension}
+                      className="grid gap-1.5 sm:grid-cols-[minmax(0,8rem)_1fr] sm:items-center"
+                    >
+                      <span className="text-muted-foreground text-[13px]">
+                        {t.venueComments.dimensions[dimension]}
+                      </span>
+                      <div
+                        role="radiogroup"
+                        aria-label={fillTemplate(
+                          t.venueComments.dimensionGroupLabel,
+                          { dimension: t.venueComments.dimensions[dimension] },
+                        )}
+                        className="flex items-center"
+                      >
+                        {STARS.map((n) => {
+                          const filled = (draft[dimension] ?? 0) >= n;
+                          return (
+                            <button
+                              key={n}
+                              type="button"
+                              role="radio"
+                              aria-checked={draft[dimension] === n}
+                              aria-label={fillTemplate(
+                                t.venueComments.starLabel,
+                                {
+                                  dimension:
+                                    t.venueComments.dimensions[dimension],
+                                  n: String(n),
+                                },
+                              )}
+                              disabled={ratingPending}
+                              onClick={() => setDraftScore(dimension, n)}
+                              className={cn(
+                                "grid size-11 place-items-center rounded-md",
+                                "transition-colors duration-150",
+                                "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none",
+                                "disabled:cursor-not-allowed disabled:opacity-60",
+                                filled
+                                  ? "text-foreground"
+                                  : "text-muted-foreground hover:text-foreground",
+                              )}
+                            >
+                              <Star
+                                className="size-5"
+                                aria-hidden="true"
+                                fill={filled ? "currentColor" : "none"}
+                              />
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                {completeDraft === null ? (
+                  <p className="text-muted-foreground mt-2 text-[13px]">
+                    {t.venueComments.ratingIncomplete}
                   </p>
                 ) : null}
+
+                <button
+                  type="button"
+                  disabled={saveDisabled}
+                  onClick={saveRating}
+                  className={cn(
+                    "border-foreground text-foreground hover:bg-secondary focus-visible:ring-ring mt-4 inline-flex h-11 items-center rounded-md border px-4 text-sm font-medium",
+                    "focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-55",
+                  )}
+                >
+                  {ratingPending
+                    ? t.venueComments.ratingSaving
+                    : t.venueComments.ratingSave}
+                </button>
 
                 {/* Inline status: error (rolled back) or saved. */}
                 {ratingErrorText ? (

--- a/src/islands/VenueComments.tsx
+++ b/src/islands/VenueComments.tsx
@@ -41,6 +41,7 @@ import {
   RATING_DIMENSIONS,
   RATING_MAX,
   RATING_MIN,
+  sameRatingScores,
   type RatingDimension,
   type RatingDimensionScores,
   type VenueRatingSummaryDto,
@@ -88,16 +89,6 @@ const SHEET_ANIM_MS = 250;
 
 type RatingErrorKey = "limit" | "network" | "server";
 type RatingDraft = Partial<RatingDimensionScores>;
-
-function scoresEqual(
-  left: RatingDimensionScores | null,
-  right: RatingDimensionScores | null,
-): boolean {
-  if (left === null || right === null) return left === right;
-  return RATING_DIMENSIONS.every(
-    (dimension) => left[dimension] === right[dimension],
-  );
-}
 
 function isCompleteDraft(draft: RatingDraft): draft is RatingDimensionScores {
   return RATING_DIMENSIONS.every((dimension) => draft[dimension] !== undefined);
@@ -197,7 +188,7 @@ export default function VenueComments({
 
   const saveRating = useCallback(() => {
     if (ratingPending || !isCompleteDraft(draft)) return;
-    if (scoresEqual(summary.yourScores, draft)) return;
+    if (sameRatingScores(summary.yourScores, draft)) return;
     const previous = summary;
     const previousDraft = draft;
 
@@ -267,7 +258,7 @@ export default function VenueComments({
   const saveDisabled =
     ratingPending ||
     completeDraft === null ||
-    scoresEqual(summary.yourScores, completeDraft);
+    sameRatingScores(summary.yourScores, completeDraft);
   const ratingErrorText =
     ratingError === "limit"
       ? t.venueComments.ratingLimit

--- a/src/lib/venue-rating-client.ts
+++ b/src/lib/venue-rating-client.ts
@@ -5,6 +5,7 @@
 // localized inline copy (R9).
 
 import type {
+  RatingDimensionScores,
   RatingErrorCode,
   RatingRequest,
   RatingResponse,
@@ -38,10 +39,10 @@ async function parseErrorCode(
  */
 export async function submitRating(
   venueId: string,
-  score: number,
+  scores: RatingDimensionScores,
   signal?: AbortSignal,
 ): Promise<RatingResponse> {
-  const body: RatingRequest = { venueId, score };
+  const body: RatingRequest = { venueId, scores };
   let res: Response;
   try {
     res = await fetch("/api/rating", {

--- a/src/lib/venue-rating.test.ts
+++ b/src/lib/venue-rating.test.ts
@@ -2,16 +2,24 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   applyOptimisticRating,
+  emptyRatingSums,
   isValidRatingScore,
-  ratingAverage,
+  isValidRatingScores,
+  ratingDimensionAverage,
+  ratingOverallAverage,
+  RATING_DIMENSIONS,
   RATING_MAX,
   RATING_MIN,
+  type RatingDimensionScores,
   type VenueRatingSummaryDto,
 } from "./venue-rating.ts";
 
-// These pure helpers ARE the rating math contract: the server's batch writes
-// (src/server/ratings.ts) and the island's optimistic state both follow the
-// transitions asserted here, so a drift in either is a failure of this spec.
+const scores: RatingDimensionScores = {
+  view: 5,
+  sound: 4,
+  amenities: 3,
+  transit: 5,
+};
 
 describe("isValidRatingScore", () => {
   it("accepts every integer in RATING_MIN..RATING_MAX", () => {
@@ -36,56 +44,125 @@ describe("isValidRatingScore", () => {
   });
 });
 
-describe("ratingAverage", () => {
-  it("returns null when nobody rated (callers render the zero state)", () => {
-    assert.equal(ratingAverage(0, 0), null);
+describe("isValidRatingScores", () => {
+  it("accepts exactly the four required dimensions", () => {
+    assert.equal(isValidRatingScores(scores), true);
   });
 
-  it("rounds to one decimal", () => {
-    assert.equal(ratingAverage(3, 13), 4.3); // 4.333…
-    assert.equal(ratingAverage(3, 14), 4.7); // 4.666…
-    assert.equal(ratingAverage(2, 9), 4.5);
-    assert.equal(ratingAverage(1, 5), 5);
+  it("rejects missing, extra, malformed, or out-of-range dimensions", () => {
+    assert.equal(isValidRatingScores({ ...scores, transit: undefined }), false);
+    assert.equal(isValidRatingScores({ ...scores, extra: 4 }), false);
+    assert.equal(isValidRatingScores({ ...scores, view: 3.5 }), false);
+    assert.equal(isValidRatingScores({ ...scores, sound: 6 }), false);
+    assert.equal(isValidRatingScores(null), false);
+  });
+});
+
+describe("rating averages", () => {
+  it("returns null when nobody rated", () => {
+    const summary: VenueRatingSummaryDto = {
+      count: 0,
+      sums: emptyRatingSums(),
+      yourScores: null,
+    };
+    assert.equal(ratingOverallAverage(summary), null);
+    assert.equal(
+      ratingDimensionAverage(summary.count, summary.sums, "view"),
+      null,
+    );
+  });
+
+  it("rounds dimension averages to one decimal", () => {
+    assert.equal(
+      ratingDimensionAverage(
+        3,
+        { view: 13, sound: 14, amenities: 9, transit: 5 },
+        "view",
+      ),
+      4.3,
+    );
+    assert.equal(
+      ratingDimensionAverage(
+        3,
+        { view: 13, sound: 14, amenities: 9, transit: 5 },
+        "sound",
+      ),
+      4.7,
+    );
+  });
+
+  it("computes overall from raw sums before dimension rounding", () => {
+    const summary: VenueRatingSummaryDto = {
+      count: 3,
+      sums: { view: 13, sound: 14, amenities: 10, transit: 15 },
+      yourScores: null,
+    };
+    assert.equal(ratingOverallAverage(summary), 4.3);
   });
 });
 
 describe("applyOptimisticRating", () => {
-  const fresh: VenueRatingSummaryDto = { count: 12, sum: 51, yourScore: null };
+  const fresh: VenueRatingSummaryDto = {
+    count: 12,
+    sums: { view: 51, sound: 48, amenities: 42, transit: 55 },
+    yourScores: null,
+  };
 
-  it("new rating: count + 1, sum + score, yourScore set", () => {
-    assert.deepEqual(applyOptimisticRating(fresh, 4), {
+  it("new rating: count + 1, each sum increases, yourScores set", () => {
+    assert.deepEqual(applyOptimisticRating(fresh, scores), {
       count: 13,
-      sum: 55,
-      yourScore: 4,
+      sums: { view: 56, sound: 52, amenities: 45, transit: 60 },
+      yourScores: scores,
     });
   });
 
-  it("score change: count unchanged, sum moves by the delta", () => {
-    const rated: VenueRatingSummaryDto = { count: 13, sum: 55, yourScore: 4 };
-    assert.deepEqual(applyOptimisticRating(rated, 2), {
+  it("score change: count unchanged, each sum moves by its own delta", () => {
+    const rated: VenueRatingSummaryDto = {
       count: 13,
-      sum: 53, // 55 - 4 + 2
-      yourScore: 2,
+      sums: { view: 56, sound: 52, amenities: 45, transit: 60 },
+      yourScores: scores,
+    };
+    assert.deepEqual(
+      applyOptimisticRating(rated, {
+        view: 4,
+        sound: 4,
+        amenities: 5,
+        transit: 5,
+      }),
+      {
+        count: 13,
+        sums: { view: 55, sound: 52, amenities: 47, transit: 60 },
+        yourScores: { view: 4, sound: 4, amenities: 5, transit: 5 },
+      },
+    );
+  });
+
+  it("same scores: idempotent no-op", () => {
+    const rated: VenueRatingSummaryDto = {
+      count: 13,
+      sums: { view: 56, sound: 52, amenities: 45, transit: 60 },
+      yourScores: scores,
+    };
+    assert.deepEqual(applyOptimisticRating(rated, scores), rated);
+  });
+
+  it("does not mutate the input summary or scores", () => {
+    const before: VenueRatingSummaryDto = {
+      count: 2,
+      sums: { view: 8, sound: 7, amenities: 6, transit: 9 },
+      yourScores: null,
+    };
+    applyOptimisticRating(before, scores);
+    assert.deepEqual(before, {
+      count: 2,
+      sums: { view: 8, sound: 7, amenities: 6, transit: 9 },
+      yourScores: null,
     });
-  });
-
-  it("same score: idempotent no-op (no count or sum drift)", () => {
-    const rated: VenueRatingSummaryDto = { count: 13, sum: 55, yourScore: 4 };
-    assert.deepEqual(applyOptimisticRating(rated, 4), rated);
-  });
-
-  it("first rating on an unrated venue starts the aggregate", () => {
-    const empty: VenueRatingSummaryDto = { count: 0, sum: 0, yourScore: null };
-    assert.deepEqual(applyOptimisticRating(empty, 5), {
-      count: 1,
-      sum: 5,
-      yourScore: 5,
-    });
-  });
-
-  it("does not mutate the input summary (rollback keeps the original)", () => {
-    const before: VenueRatingSummaryDto = { count: 2, sum: 7, yourScore: null };
-    applyOptimisticRating(before, 3);
-    assert.deepEqual(before, { count: 2, sum: 7, yourScore: null });
+    assert.deepEqual(RATING_DIMENSIONS, [
+      "view",
+      "sound",
+      "amenities",
+      "transit",
+    ]);
   });
 });

--- a/src/lib/venue-rating.ts
+++ b/src/lib/venue-rating.ts
@@ -134,39 +134,40 @@ export function ratingOverallAverage(
 }
 
 /**
+ * Whether two dimension-score sets are identical. The single equality used by
+ * the client's optimistic gate, the server's no-op detection AND the
+ * optimistic-apply below, so those three layers cannot drift. `null` (no
+ * rating yet) compares by identity — it equals only another `null`.
+ */
+export function sameRatingScores(
+  left: RatingDimensionScores | null,
+  right: RatingDimensionScores | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return RATING_DIMENSIONS.every(
+    (dimension) => left[dimension] === right[dimension],
+  );
+}
+
+/**
  * Pure optimistic-apply for the rating control: the same transition the server
- * performs in D1 (new rating → count+1, sum+score; score change → count stays,
- * sum moves by the delta; same score → no-op). Keeping this in the shared
- * contract means the client's optimistic state can never disagree with the
- * server's batch math.
+ * performs in D1. A first rating is the score-change case with the previous
+ * scores treated as zero and count+1, so both share one reduce — keeping this
+ * in the shared contract means the client's optimistic state can never disagree
+ * with the server's batch math.
  */
 export function applyOptimisticRating(
   summary: VenueRatingSummaryDto,
   scores: RatingDimensionScores,
 ): VenueRatingSummaryDto {
-  if (summary.yourScores === null) {
-    return {
-      count: summary.count + 1,
-      sums: RATING_DIMENSIONS.reduce<RatingDimensionScores>(
-        (next, dimension) => {
-          next[dimension] = summary.sums[dimension] + scores[dimension];
-          return next;
-        },
-        emptyRatingSums(),
-      ),
-      yourScores: { ...scores },
-    };
-  }
-  const unchanged = RATING_DIMENSIONS.every(
-    (dimension) => summary.yourScores?.[dimension] === scores[dimension],
-  );
-  if (unchanged) return summary;
+  if (sameRatingScores(summary.yourScores, scores)) return summary;
+  const previous = summary.yourScores;
   return {
-    count: summary.count,
+    count: summary.count + (previous === null ? 1 : 0),
     sums: RATING_DIMENSIONS.reduce<RatingDimensionScores>((next, dimension) => {
       next[dimension] =
         summary.sums[dimension] -
-        (summary.yourScores?.[dimension] ?? 0) +
+        (previous?.[dimension] ?? 0) +
         scores[dimension];
       return next;
     }, emptyRatingSums()),

--- a/src/lib/venue-rating.ts
+++ b/src/lib/venue-rating.ts
@@ -1,5 +1,5 @@
 // Shared venue-rating contract — the cross-layer source of truth for the
-// anonymous 1..5-star venue rating (task 06-10-giscus, prd "评分后端").
+// anonymous venue rating dimensions.
 // The rating control (client), the /api/rating route (server) and the D1
 // `venue_ratings` / `venue_rating_agg` rows all agree on these names + limits
 // here so a field cannot drift between layers (cross-layer-thinking-guide).
@@ -11,6 +11,14 @@
 /** Valid score bounds (inclusive). */
 export const RATING_MIN = 1;
 export const RATING_MAX = 5;
+export const RATING_DIMENSIONS = [
+  "view",
+  "sound",
+  "amenities",
+  "transit",
+] as const;
+export type RatingDimension = (typeof RATING_DIMENSIONS)[number];
+export type RatingDimensionScores = Record<RatingDimension, number>;
 
 /**
  * Daily cap per IP: at most 10 DIFFERENT venues newly rated per UTC day (KV
@@ -29,10 +37,26 @@ export function isValidRatingScore(value: unknown): value is number {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Type guard: exactly the four required rating dimensions, all 1..5 ints. */
+export function isValidRatingScores(
+  value: unknown,
+): value is RatingDimensionScores {
+  if (!isRecord(value)) return false;
+  const keys = Object.keys(value);
+  if (keys.length !== RATING_DIMENSIONS.length) return false;
+  return RATING_DIMENSIONS.every((dimension) =>
+    isValidRatingScore(value[dimension]),
+  );
+}
+
 /** POST /api/rating body. */
 export interface RatingRequest {
   venueId: string;
-  score: number;
+  scores: RatingDimensionScores;
 }
 
 /**
@@ -43,8 +67,8 @@ export interface RatingRequest {
 export interface RatingResponse {
   venueId: string;
   ratingCount: number;
-  ratingSum: number;
-  yourScore: number;
+  ratingSums: RatingDimensionScores;
+  yourScores: RatingDimensionScores;
 }
 
 /**
@@ -54,10 +78,10 @@ export interface RatingResponse {
 export interface VenueRatingSummaryDto {
   /** How many different IPs rated this venue. */
   count: number;
-  /** Sum of all scores (avg = sum / count). */
-  sum: number;
-  /** THIS viewer's current score (by ip_hash), null when not rated yet. */
-  yourScore: number | null;
+  /** Sum of each dimension (avg = sums[dimension] / count). */
+  sums: RatingDimensionScores;
+  /** THIS viewer's current dimension scores, null when not rated yet. */
+  yourScores: RatingDimensionScores | null;
 }
 
 /**
@@ -81,6 +105,34 @@ export function ratingAverage(count: number, sum: number): number | null {
   return Math.round((sum / count) * 10) / 10;
 }
 
+export function emptyRatingSums(): RatingDimensionScores {
+  return {
+    view: 0,
+    sound: 0,
+    amenities: 0,
+    transit: 0,
+  };
+}
+
+export function ratingDimensionAverage(
+  count: number,
+  sums: RatingDimensionScores,
+  dimension: RatingDimension,
+): number | null {
+  return ratingAverage(count, sums[dimension]);
+}
+
+export function ratingOverallAverage(
+  summary: VenueRatingSummaryDto,
+): number | null {
+  if (summary.count <= 0) return null;
+  const total = RATING_DIMENSIONS.reduce(
+    (sum, dimension) => sum + summary.sums[dimension],
+    0,
+  );
+  return ratingAverage(summary.count * RATING_DIMENSIONS.length, total);
+}
+
 /**
  * Pure optimistic-apply for the rating control: the same transition the server
  * performs in D1 (new rating → count+1, sum+score; score change → count stays,
@@ -90,19 +142,34 @@ export function ratingAverage(count: number, sum: number): number | null {
  */
 export function applyOptimisticRating(
   summary: VenueRatingSummaryDto,
-  score: number,
+  scores: RatingDimensionScores,
 ): VenueRatingSummaryDto {
-  if (summary.yourScore === null) {
+  if (summary.yourScores === null) {
     return {
       count: summary.count + 1,
-      sum: summary.sum + score,
-      yourScore: score,
+      sums: RATING_DIMENSIONS.reduce<RatingDimensionScores>(
+        (next, dimension) => {
+          next[dimension] = summary.sums[dimension] + scores[dimension];
+          return next;
+        },
+        emptyRatingSums(),
+      ),
+      yourScores: { ...scores },
     };
   }
-  if (summary.yourScore === score) return summary;
+  const unchanged = RATING_DIMENSIONS.every(
+    (dimension) => summary.yourScores?.[dimension] === scores[dimension],
+  );
+  if (unchanged) return summary;
   return {
     count: summary.count,
-    sum: summary.sum - summary.yourScore + score,
-    yourScore: score,
+    sums: RATING_DIMENSIONS.reduce<RatingDimensionScores>((next, dimension) => {
+      next[dimension] =
+        summary.sums[dimension] -
+        (summary.yourScores?.[dimension] ?? 0) +
+        scores[dimension];
+      return next;
+    }, emptyRatingSums()),
+    yourScores: { ...scores },
   };
 }

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -26,7 +26,7 @@ import { getDb } from "@/server/db";
 import { listSubMapPhotos } from "@/server/photos";
 import { getRatingSummary } from "@/server/ratings";
 import type { PhotoDto } from "@/lib/photos";
-import type { VenueRatingSummaryDto } from "@/lib/venue-rating";
+import { emptyRatingSums, type VenueRatingSummaryDto } from "@/lib/venue-rating";
 
 export const prerender = false;
 
@@ -71,7 +71,11 @@ const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
 // AVG over rating rows) + this viewer's own score (by salted ip_hash, same
 // privacy model as staging votedByMe). Fails soft to a zero summary so a D1
 // hiccup never 500s the page; the entry chip then shows its zero state.
-let ratingSummary: VenueRatingSummaryDto = { count: 0, sum: 0, yourScore: null };
+let ratingSummary: VenueRatingSummaryDto = {
+  count: 0,
+  sums: emptyRatingSums(),
+  yourScores: null,
+};
 if (venue && env.DB) {
   try {
     const viewerIpHash = env.TURNSTILE_SECRET_KEY
@@ -83,7 +87,11 @@ if (venue && env.DB) {
       viewerIpHash,
     );
   } catch {
-    ratingSummary = { count: 0, sum: 0, yourScore: null };
+    ratingSummary = {
+      count: 0,
+      sums: emptyRatingSums(),
+      yourScores: null,
+    };
   }
 }
 

--- a/src/pages/api/rating.ts
+++ b/src/pages/api/rating.ts
@@ -12,7 +12,7 @@ import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { clientIp, hashIp } from "@/server/ip";
 import { getDb } from "@/server/db";
-import { hasViewerRating, rateVenue } from "@/server/ratings";
+import { getViewerRatingRow, rateVenue } from "@/server/ratings";
 import { checkDailyLimit, incrementDaily } from "@/server/rate-limit";
 import { getVenue } from "@/data/venues";
 import {
@@ -72,9 +72,11 @@ export const POST: APIRoute = async ({ request }) => {
     const db = getDb(env.DB);
 
     // The daily cap only guards NEW venues rated today; changing an existing
-    // score must keep working even at the cap (it creates nothing new).
-    const existing = await hasViewerRating(db, venueId, ipHash);
-    if (!existing) {
+    // score must keep working even at the cap (it creates nothing new). Read the
+    // viewer's row ONCE here and hand it to rateVenue so the write path does not
+    // re-SELECT the same (venue_id, ip_hash) (D1 bills rows read).
+    const existingRow = await getViewerRatingRow(db, venueId, ipHash);
+    if (!existingRow) {
       const limit = await checkDailyLimit(
         env.RATE_LIMIT,
         "rating",
@@ -87,7 +89,9 @@ export const POST: APIRoute = async ({ request }) => {
       }
     }
 
-    const outcome = await rateVenue(db, venueId, ipHash, scores);
+    const outcome = await rateVenue(db, venueId, ipHash, scores, {
+      existingRow,
+    });
 
     // Quota is consumed only after the protected write succeeds (rate-limit
     // contract), and only for a genuinely new rating. Best-effort, matching

--- a/src/pages/api/rating.ts
+++ b/src/pages/api/rating.ts
@@ -1,6 +1,6 @@
 // /api/rating — record (or change) an anonymous 1..5-star venue rating.
 //
-// POST { venueId, score } → 200 { venueId, ratingCount, ratingSum, yourScore }.
+// POST { venueId, scores } → 200 { venueId, ratingCount, ratingSums, yourScores }.
 // Mirrors /api/staging/vote: NO Turnstile (a single click; a challenge per
 // rating would wreck the UX). Abuse is bounded by UNIQUE(venue_id, ip_hash) in
 // D1 (a repeat rating is a score CHANGE, never a second row) + a KV daily cap
@@ -12,12 +12,12 @@ import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
 import { clientIp, hashIp } from "@/server/ip";
 import { getDb } from "@/server/db";
-import { getViewerScore, rateVenue } from "@/server/ratings";
+import { hasViewerRating, rateVenue } from "@/server/ratings";
 import { checkDailyLimit, incrementDaily } from "@/server/rate-limit";
 import { getVenue } from "@/data/venues";
 import {
   RATING_DAILY_LIMIT,
-  isValidRatingScore,
+  isValidRatingScores,
   type RatingErrorCode,
   type RatingRequest,
   type RatingResponse,
@@ -56,7 +56,7 @@ export const POST: APIRoute = async ({ request }) => {
     return jsonError("missing_fields", 400);
   }
   const venueId = typeof body.venueId === "string" ? body.venueId.trim() : "";
-  if (venueId.length === 0 || !isValidRatingScore(body.score)) {
+  if (venueId.length === 0 || !isValidRatingScores(body.scores)) {
     return jsonError("missing_fields", 400);
   }
   // Ratings only attach to venues that exist in the static atlas (ADR-1) — D1
@@ -64,7 +64,7 @@ export const POST: APIRoute = async ({ request }) => {
   if (!getVenue(venueId)) {
     return jsonError("venue_not_found", 404);
   }
-  const score = body.score;
+  const scores = body.scores;
 
   const ipHash = await hashIp(clientIp(request), secret);
 
@@ -73,8 +73,8 @@ export const POST: APIRoute = async ({ request }) => {
 
     // The daily cap only guards NEW venues rated today; changing an existing
     // score must keep working even at the cap (it creates nothing new).
-    const existing = await getViewerScore(db, venueId, ipHash);
-    if (existing === null) {
+    const existing = await hasViewerRating(db, venueId, ipHash);
+    if (!existing) {
       const limit = await checkDailyLimit(
         env.RATE_LIMIT,
         "rating",
@@ -87,7 +87,7 @@ export const POST: APIRoute = async ({ request }) => {
       }
     }
 
-    const outcome = await rateVenue(db, venueId, ipHash, score);
+    const outcome = await rateVenue(db, venueId, ipHash, scores);
 
     // Quota is consumed only after the protected write succeeds (rate-limit
     // contract), and only for a genuinely new rating. Best-effort, matching
@@ -106,8 +106,8 @@ export const POST: APIRoute = async ({ request }) => {
     const payload: RatingResponse = {
       venueId,
       ratingCount: outcome.ratingCount,
-      ratingSum: outcome.ratingSum,
-      yourScore: score,
+      ratingSums: outcome.ratingSums,
+      yourScores: scores,
     };
     return new Response(JSON.stringify(payload), {
       status: 200,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -85,7 +85,7 @@ export const stagingVotes = sqliteTable(
 );
 
 /**
- * One anonymous 1..5-star rating of a collected venue (task 06-10-giscus).
+ * One anonymous 1..5-star dimensional rating of a collected venue.
  * The rated venue is a STATIC venue id (data/venues/*.json, ADR-1), validated
  * against the bundled set at the API layer — D1 has no venues table to FK.
  *
@@ -99,7 +99,13 @@ export const venueRatings = sqliteTable(
   {
     id: text("id").primaryKey(), // ulid
     venueId: text("venue_id").notNull(),
-    score: integer("score").notNull(), // 1..5, validated at the API layer
+    // Legacy compatibility score. New writes store the rounded row mean here,
+    // but public display reads only the dimensional columns/aggregate.
+    score: integer("score").notNull(),
+    viewScore: integer("view_score"),
+    soundScore: integer("sound_score"),
+    amenitiesScore: integer("amenities_score"),
+    transitScore: integer("transit_score"),
     ipHash: text("ip_hash").notNull(),
     createdAt: integer("created_at").notNull(),
     updatedAt: integer("updated_at"), // last score change, null = never changed
@@ -114,12 +120,18 @@ export const venueRatings = sqliteTable(
  * page SSR) reads exactly this row — never `AVG()` over `venue_ratings` (D1
  * bills rows read; same reasoning as `stagingVenues.voteCount`). Kept in sync
  * with `venue_ratings` in the SAME `db.batch` as every rating write (atomic).
- * `rating_sum` is an integer so `avg = sum / count` avoids stored floats.
+ * Legacy `rating_count` / `rating_sum` are preserved for rollback/export.
+ * New display reads `dimension_rating_count` and the four dimension sums.
  */
 export const venueRatingAgg = sqliteTable("venue_rating_agg", {
   venueId: text("venue_id").primaryKey(),
   ratingCount: integer("rating_count").notNull().default(0),
   ratingSum: integer("rating_sum").notNull().default(0),
+  dimensionRatingCount: integer("dimension_rating_count").notNull().default(0),
+  viewRatingSum: integer("view_rating_sum").notNull().default(0),
+  soundRatingSum: integer("sound_rating_sum").notNull().default(0),
+  amenitiesRatingSum: integer("amenities_rating_sum").notNull().default(0),
+  transitRatingSum: integer("transit_rating_sum").notNull().default(0),
   updatedAt: integer("updated_at").notNull(),
 });
 

--- a/src/server/ratings.ts
+++ b/src/server/ratings.ts
@@ -10,6 +10,7 @@ import type { Db } from "@/server/db";
 import {
   emptyRatingSums,
   isValidRatingScores,
+  RATING_DIMENSIONS,
   sameRatingScores,
   type RatingDimensionScores,
   type VenueRatingSummaryDto,
@@ -47,9 +48,8 @@ function rowToScores(
 }
 
 function legacyMeanScore(scores: RatingDimensionScores): number {
-  return Math.round(
-    (scores.view + scores.sound + scores.amenities + scores.transit) / 4,
-  );
+  const total = RATING_DIMENSIONS.reduce((sum, d) => sum + scores[d], 0);
+  return Math.round(total / RATING_DIMENSIONS.length);
 }
 
 // A per-(venue, viewer) scalar subquery: reads ONE rating column's pre-update

--- a/src/server/ratings.ts
+++ b/src/server/ratings.ts
@@ -1,41 +1,110 @@
-// D1 queries for the anonymous venue rating (task 06-10-giscus).
+// D1 queries for anonymous venue rating dimensions.
 //
-// Mirrors src/server/staging.ts in shape: a read helper (the SSR summary) and
-// a write helper (UPSERT one rating + keep the denormalized aggregate in the
-// SAME atomic `db.batch`). The rated venue id is STATIC metadata
-// (data/venues/*.json, ADR-1) and is validated by the API route against the
-// bundled set — D1 never stores venues, only ratings.
-//
-// Consistency model (why every write is one batch):
-//   • new rating  → INSERT rating row + agg upsert (count+1, sum+score). A
-//     concurrent duplicate fails the rating row's UNIQUE index, which rolls
-//     the whole batch back (agg never drifts) — same backstop as
-//     staging.addVote.
-//   • score change → the agg statement derives the OLD score from the rating
-//     row itself via a subquery INSIDE the batch (never from a pre-read that
-//     could be stale by write time — same "no stale pre-read" rule as the
-//     photo-corrections approve path), then the row update overwrites it.
-// `ip_hash` is the salted hash (server/ip.ts), never the raw IP, and is never
-// sent to the client.
+// Public display reads only the denormalized dimensional aggregate. Legacy
+// single-score fields remain for rollback/export, but are never fanned out into
+// dimension values.
 
 import { and, eq, sql } from "drizzle-orm";
 import type { Db } from "@/server/db";
-import type { VenueRatingSummaryDto } from "@/lib/venue-rating";
+import {
+  emptyRatingSums,
+  isValidRatingScores,
+  type RatingDimensionScores,
+  type VenueRatingSummaryDto,
+} from "@/lib/venue-rating";
 import { newId } from "@/server/id";
 import { venueRatingAgg, venueRatings } from "@/server/db/schema";
 
-/** Outcome of a {@link rateVenue} attempt — mapped to HTTP by the endpoint. */
+/** Outcome of a {@link rateVenue} attempt, mapped to HTTP by the endpoint. */
 export type RateVenueOutcome = {
   /** `created` consumes daily quota; `updated`/`unchanged` do not. */
   status: "created" | "updated" | "unchanged";
   ratingCount: number;
-  ratingSum: number;
+  ratingSums: RatingDimensionScores;
 };
 
+type ViewerRatingRow = {
+  score: number;
+  viewScore: number | null;
+  soundScore: number | null;
+  amenitiesScore: number | null;
+  transitScore: number | null;
+};
+
+function rowToScores(
+  row: ViewerRatingRow | undefined,
+): RatingDimensionScores | null {
+  if (!row) return null;
+  const scores = {
+    view: row.viewScore,
+    sound: row.soundScore,
+    amenities: row.amenitiesScore,
+    transit: row.transitScore,
+  };
+  return isValidRatingScores(scores) ? scores : null;
+}
+
+function legacyMeanScore(scores: RatingDimensionScores): number {
+  return Math.round(
+    (scores.view + scores.sound + scores.amenities + scores.transit) / 4,
+  );
+}
+
+function sameScores(
+  left: RatingDimensionScores,
+  right: RatingDimensionScores,
+): boolean {
+  return (
+    left.view === right.view &&
+    left.sound === right.sound &&
+    left.amenities === right.amenities &&
+    left.transit === right.transit
+  );
+}
+
+async function getViewerRatingRow(
+  db: Db,
+  venueId: string,
+  ipHash: string,
+): Promise<ViewerRatingRow | undefined> {
+  return (
+    await db
+      .select({
+        score: venueRatings.score,
+        viewScore: venueRatings.viewScore,
+        soundScore: venueRatings.soundScore,
+        amenitiesScore: venueRatings.amenitiesScore,
+        transitScore: venueRatings.transitScore,
+      })
+      .from(venueRatings)
+      .where(
+        and(eq(venueRatings.venueId, venueId), eq(venueRatings.ipHash, ipHash)),
+      )
+      .limit(1)
+  )[0];
+}
+
+/** Whether this viewer already has any rating row, legacy or dimensional. */
+export async function hasViewerRating(
+  db: Db,
+  venueId: string,
+  ipHash: string,
+): Promise<boolean> {
+  return (await getViewerRatingRow(db, venueId, ipHash)) !== undefined;
+}
+
+/** This viewer's complete dimensional score set, or null when absent/legacy. */
+export async function getViewerScores(
+  db: Db,
+  venueId: string,
+  ipHash: string,
+): Promise<RatingDimensionScores | null> {
+  return rowToScores(await getViewerRatingRow(db, venueId, ipHash));
+}
+
 /**
- * Read the display aggregate (1 indexed row — NEVER an AVG over the rating
- * rows) plus, when the viewer's ip_hash is known, their own current score so
- * the star control can render the "you rated N" state.
+ * Read the display aggregate (1 indexed row, never an AVG over rating rows)
+ * plus, when the viewer's ip_hash is known, their own complete dimension scores.
  */
 export async function getRatingSummary(
   db: Db,
@@ -45,94 +114,137 @@ export async function getRatingSummary(
   const agg = (
     await db
       .select({
-        ratingCount: venueRatingAgg.ratingCount,
-        ratingSum: venueRatingAgg.ratingSum,
+        ratingCount: venueRatingAgg.dimensionRatingCount,
+        viewRatingSum: venueRatingAgg.viewRatingSum,
+        soundRatingSum: venueRatingAgg.soundRatingSum,
+        amenitiesRatingSum: venueRatingAgg.amenitiesRatingSum,
+        transitRatingSum: venueRatingAgg.transitRatingSum,
       })
       .from(venueRatingAgg)
       .where(eq(venueRatingAgg.venueId, venueId))
       .limit(1)
   )[0];
 
-  let yourScore: number | null = null;
+  let yourScores: RatingDimensionScores | null = null;
   if (viewerIpHash) {
-    yourScore = await getViewerScore(db, venueId, viewerIpHash);
+    yourScores = await getViewerScores(db, venueId, viewerIpHash);
   }
 
   return {
     count: agg?.ratingCount ?? 0,
-    sum: agg?.ratingSum ?? 0,
-    yourScore,
+    sums: agg
+      ? {
+          view: agg.viewRatingSum,
+          sound: agg.soundRatingSum,
+          amenities: agg.amenitiesRatingSum,
+          transit: agg.transitRatingSum,
+        }
+      : emptyRatingSums(),
+    yourScores,
   };
 }
 
-/** This viewer's current score for a venue, or null when not rated yet. */
-export async function getViewerScore(
-  db: Db,
-  venueId: string,
-  ipHash: string,
-): Promise<number | null> {
-  const row = (
-    await db
-      .select({ score: venueRatings.score })
-      .from(venueRatings)
-      .where(
-        and(eq(venueRatings.venueId, venueId), eq(venueRatings.ipHash, ipHash)),
-      )
-      .limit(1)
-  )[0];
-  return row?.score ?? null;
-}
-
-/** Authoritative post-write aggregate (the response the client reconciles to). */
+/** Authoritative post-write aggregate for response reconciliation. */
 async function readAgg(
   db: Db,
   venueId: string,
-): Promise<{ ratingCount: number; ratingSum: number }> {
-  const agg = (
-    await db
-      .select({
-        ratingCount: venueRatingAgg.ratingCount,
-        ratingSum: venueRatingAgg.ratingSum,
-      })
-      .from(venueRatingAgg)
-      .where(eq(venueRatingAgg.venueId, venueId))
-      .limit(1)
-  )[0];
-  return { ratingCount: agg?.ratingCount ?? 0, ratingSum: agg?.ratingSum ?? 0 };
+): Promise<{ ratingCount: number; ratingSums: RatingDimensionScores }> {
+  const summary = await getRatingSummary(db, venueId);
+  return { ratingCount: summary.count, ratingSums: summary.sums };
 }
 
-/**
- * Apply a score CHANGE for an existing (venueId, ipHash) rating. The aggregate
- * statement reads the old score from the rating row itself (subquery) inside
- * the atomic batch, so a concurrent change can never make the tally drift —
- * statements in one batch see a consistent row, and D1 serializes batches.
- * Statement order matters: the agg update must run BEFORE the row update so
- * the subquery still sees the old score.
- */
-async function applyScoreChange(
+const hasCompleteDimensionScores = sql`
+  ${venueRatings.viewScore} is not null and
+  ${venueRatings.soundScore} is not null and
+  ${venueRatings.amenitiesScore} is not null and
+  ${venueRatings.transitScore} is not null
+`;
+
+async function applyDimensionChange(
   db: Db,
   venueId: string,
   ipHash: string,
-  score: number,
+  scores: RatingDimensionScores,
   now: number,
 ): Promise<void> {
+  const oldView = sql`(select ${venueRatings.viewScore} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
+  const oldSound = sql`(select ${venueRatings.soundScore} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
+  const oldAmenities = sql`(select ${venueRatings.amenitiesScore} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
+  const oldTransit = sql`(select ${venueRatings.transitScore} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
   const oldScore = sql`(select ${venueRatings.score} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
+  const score = legacyMeanScore(scores);
+
   await db.batch([
     db
       .update(venueRatingAgg)
       .set({
         ratingSum: sql`${venueRatingAgg.ratingSum} + ${score} - ${oldScore}`,
+        viewRatingSum: sql`${venueRatingAgg.viewRatingSum} + ${scores.view} - ${oldView}`,
+        soundRatingSum: sql`${venueRatingAgg.soundRatingSum} + ${scores.sound} - ${oldSound}`,
+        amenitiesRatingSum: sql`${venueRatingAgg.amenitiesRatingSum} + ${scores.amenities} - ${oldAmenities}`,
+        transitRatingSum: sql`${venueRatingAgg.transitRatingSum} + ${scores.transit} - ${oldTransit}`,
         updatedAt: now,
       })
       .where(
         and(
           eq(venueRatingAgg.venueId, venueId),
-          sql`exists (select 1 from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`,
+          sql`exists (select 1 from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash} and ${hasCompleteDimensionScores})`,
         ),
       ),
     db
       .update(venueRatings)
-      .set({ score, updatedAt: now })
+      .set({
+        score,
+        viewScore: scores.view,
+        soundScore: scores.sound,
+        amenitiesScore: scores.amenities,
+        transitScore: scores.transit,
+        updatedAt: now,
+      })
+      .where(
+        and(eq(venueRatings.venueId, venueId), eq(venueRatings.ipHash, ipHash)),
+      ),
+  ]);
+}
+
+async function completeLegacyRating(
+  db: Db,
+  venueId: string,
+  ipHash: string,
+  scores: RatingDimensionScores,
+  now: number,
+): Promise<void> {
+  const oldScore = sql`(select ${venueRatings.score} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
+  const score = legacyMeanScore(scores);
+
+  await db.batch([
+    db
+      .update(venueRatingAgg)
+      .set({
+        ratingSum: sql`${venueRatingAgg.ratingSum} + ${score} - ${oldScore}`,
+        dimensionRatingCount: sql`${venueRatingAgg.dimensionRatingCount} + 1`,
+        viewRatingSum: sql`${venueRatingAgg.viewRatingSum} + ${scores.view}`,
+        soundRatingSum: sql`${venueRatingAgg.soundRatingSum} + ${scores.sound}`,
+        amenitiesRatingSum: sql`${venueRatingAgg.amenitiesRatingSum} + ${scores.amenities}`,
+        transitRatingSum: sql`${venueRatingAgg.transitRatingSum} + ${scores.transit}`,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(venueRatingAgg.venueId, venueId),
+          sql`exists (select 1 from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash} and not (${hasCompleteDimensionScores}))`,
+        ),
+      ),
+    db
+      .update(venueRatings)
+      .set({
+        score,
+        viewScore: scores.view,
+        soundScore: scores.sound,
+        amenitiesScore: scores.amenities,
+        transitScore: scores.transit,
+        updatedAt: now,
+      })
       .where(
         and(eq(venueRatings.venueId, venueId), eq(venueRatings.ipHash, ipHash)),
       ),
@@ -140,30 +252,32 @@ async function applyScoreChange(
 }
 
 /**
- * Record (or change) one viewer's score for a venue:
- *   1. no rating yet → insert + agg(count+1, sum+score) atomically → `created`
- *   2. same score already recorded → idempotent no-op → `unchanged`
- *   3. different score → change row + move agg sum by the delta → `updated`
- * The UNIQUE(venue_id, ip_hash) index is the race backstop for case 1: a
- * concurrent duplicate insert fails the batch (rolled back, agg untouched) and
- * is retried as a score change. Always returns the authoritative aggregate.
+ * Record (or change) one viewer's complete four-dimension score set.
+ * Existing legacy single-score rows become complete dimension rows and count
+ * once in the new dimensional aggregate.
  */
 export async function rateVenue(
   db: Db,
   venueId: string,
   ipHash: string,
-  score: number,
+  scores: RatingDimensionScores,
   now: number = Date.now(),
 ): Promise<RateVenueOutcome> {
-  const existing = await getViewerScore(db, venueId, ipHash);
+  const existing = await getViewerRatingRow(db, venueId, ipHash);
+  const existingScores = rowToScores(existing);
+  const score = legacyMeanScore(scores);
 
-  if (existing === null) {
+  if (!existing) {
     try {
       await db.batch([
         db.insert(venueRatings).values({
           id: newId(),
           venueId,
           score,
+          viewScore: scores.view,
+          soundScore: scores.sound,
+          amenitiesScore: scores.amenities,
+          transitScore: scores.transit,
           ipHash,
           createdAt: now,
         }),
@@ -173,6 +287,11 @@ export async function rateVenue(
             venueId,
             ratingCount: 1,
             ratingSum: score,
+            dimensionRatingCount: 1,
+            viewRatingSum: scores.view,
+            soundRatingSum: scores.sound,
+            amenitiesRatingSum: scores.amenities,
+            transitRatingSum: scores.transit,
             updatedAt: now,
           })
           .onConflictDoUpdate({
@@ -180,29 +299,40 @@ export async function rateVenue(
             set: {
               ratingCount: sql`${venueRatingAgg.ratingCount} + 1`,
               ratingSum: sql`${venueRatingAgg.ratingSum} + ${score}`,
+              dimensionRatingCount: sql`${venueRatingAgg.dimensionRatingCount} + 1`,
+              viewRatingSum: sql`${venueRatingAgg.viewRatingSum} + ${scores.view}`,
+              soundRatingSum: sql`${venueRatingAgg.soundRatingSum} + ${scores.sound}`,
+              amenitiesRatingSum: sql`${venueRatingAgg.amenitiesRatingSum} + ${scores.amenities}`,
+              transitRatingSum: sql`${venueRatingAgg.transitRatingSum} + ${scores.transit}`,
               updatedAt: now,
             },
           }),
       ]);
       return { status: "created", ...(await readAgg(db, venueId)) };
     } catch (err) {
-      // Only a UNIQUE collision (concurrent first rating from the same ip_hash)
-      // falls through to the change path; re-throw real D1 failures so the
-      // endpoint surfaces a 5xx rather than a fake success.
       if (!String(err).includes("UNIQUE")) throw err;
-      const fresh = await getViewerScore(db, venueId, ipHash);
-      if (fresh === score) {
+      const freshScores = await getViewerScores(db, venueId, ipHash);
+      if (freshScores && sameScores(freshScores, scores)) {
         return { status: "unchanged", ...(await readAgg(db, venueId)) };
       }
-      await applyScoreChange(db, venueId, ipHash, score, now);
+      if (freshScores) {
+        await applyDimensionChange(db, venueId, ipHash, scores, now);
+      } else {
+        await completeLegacyRating(db, venueId, ipHash, scores, now);
+      }
       return { status: "updated", ...(await readAgg(db, venueId)) };
     }
   }
 
-  if (existing === score) {
+  if (!existingScores) {
+    await completeLegacyRating(db, venueId, ipHash, scores, now);
+    return { status: "updated", ...(await readAgg(db, venueId)) };
+  }
+
+  if (sameScores(existingScores, scores)) {
     return { status: "unchanged", ...(await readAgg(db, venueId)) };
   }
 
-  await applyScoreChange(db, venueId, ipHash, score, now);
+  await applyDimensionChange(db, venueId, ipHash, scores, now);
   return { status: "updated", ...(await readAgg(db, venueId)) };
 }

--- a/src/server/ratings.ts
+++ b/src/server/ratings.ts
@@ -213,11 +213,11 @@ async function completeLegacyRating(
   ipHash: string,
   scores: RatingDimensionScores,
   now: number,
-): Promise<void> {
+): Promise<boolean> {
   const oldScore = sql`(select ${venueRatings.score} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
   const score = legacyMeanScore(scores);
 
-  await db.batch([
+  const [updatedAgg, updatedRating] = await db.batch([
     db
       .update(venueRatingAgg)
       .set({
@@ -234,7 +234,8 @@ async function completeLegacyRating(
           eq(venueRatingAgg.venueId, venueId),
           sql`exists (select 1 from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash} and not (${hasCompleteDimensionScores}))`,
         ),
-      ),
+      )
+      .returning({ venueId: venueRatingAgg.venueId }),
     db
       .update(venueRatings)
       .set({
@@ -246,9 +247,40 @@ async function completeLegacyRating(
         updatedAt: now,
       })
       .where(
-        and(eq(venueRatings.venueId, venueId), eq(venueRatings.ipHash, ipHash)),
-      ),
+        and(
+          eq(venueRatings.venueId, venueId),
+          eq(venueRatings.ipHash, ipHash),
+          sql`not (${hasCompleteDimensionScores})`,
+          sql`exists (select 1 from ${venueRatingAgg} where ${venueRatingAgg.venueId} = ${venueId})`,
+        ),
+      )
+      .returning({ id: venueRatings.id }),
   ]);
+
+  return updatedAgg.length > 0 && updatedRating.length > 0;
+}
+
+async function completeLegacyOrApplyFreshChange(
+  db: Db,
+  venueId: string,
+  ipHash: string,
+  scores: RatingDimensionScores,
+  now: number,
+): Promise<"updated" | "unchanged"> {
+  if (await completeLegacyRating(db, venueId, ipHash, scores, now)) {
+    return "updated";
+  }
+
+  const freshScores = await getViewerScores(db, venueId, ipHash);
+  if (!freshScores) {
+    throw new Error("legacy rating completion lost its guarded write");
+  }
+  if (sameScores(freshScores, scores)) {
+    return "unchanged";
+  }
+
+  await applyDimensionChange(db, venueId, ipHash, scores, now);
+  return "updated";
 }
 
 /**
@@ -317,16 +349,29 @@ export async function rateVenue(
       }
       if (freshScores) {
         await applyDimensionChange(db, venueId, ipHash, scores, now);
+        return { status: "updated", ...(await readAgg(db, venueId)) };
       } else {
-        await completeLegacyRating(db, venueId, ipHash, scores, now);
+        const status = await completeLegacyOrApplyFreshChange(
+          db,
+          venueId,
+          ipHash,
+          scores,
+          now,
+        );
+        return { status, ...(await readAgg(db, venueId)) };
       }
-      return { status: "updated", ...(await readAgg(db, venueId)) };
     }
   }
 
   if (!existingScores) {
-    await completeLegacyRating(db, venueId, ipHash, scores, now);
-    return { status: "updated", ...(await readAgg(db, venueId)) };
+    const status = await completeLegacyOrApplyFreshChange(
+      db,
+      venueId,
+      ipHash,
+      scores,
+      now,
+    );
+    return { status, ...(await readAgg(db, venueId)) };
   }
 
   if (sameScores(existingScores, scores)) {

--- a/src/server/ratings.ts
+++ b/src/server/ratings.ts
@@ -5,10 +5,12 @@
 // dimension values.
 
 import { and, eq, sql } from "drizzle-orm";
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
 import type { Db } from "@/server/db";
 import {
   emptyRatingSums,
   isValidRatingScores,
+  sameRatingScores,
   type RatingDimensionScores,
   type VenueRatingSummaryDto,
 } from "@/lib/venue-rating";
@@ -23,7 +25,7 @@ export type RateVenueOutcome = {
   ratingSums: RatingDimensionScores;
 };
 
-type ViewerRatingRow = {
+export type ViewerRatingRow = {
   score: number;
   viewScore: number | null;
   soundScore: number | null;
@@ -50,19 +52,62 @@ function legacyMeanScore(scores: RatingDimensionScores): number {
   );
 }
 
-function sameScores(
-  left: RatingDimensionScores,
-  right: RatingDimensionScores,
-): boolean {
-  return (
-    left.view === right.view &&
-    left.sound === right.sound &&
-    left.amenities === right.amenities &&
-    left.transit === right.transit
-  );
+// A per-(venue, viewer) scalar subquery: reads ONE rating column's pre-update
+// value from inside the same write batch, so a change never relies on a stale
+// pre-read (the "no stale pre-read" rule). One helper instead of a hand-copied
+// SELECT per column.
+function viewerColumn(
+  column: AnySQLiteColumn,
+  venueId: string,
+  ipHash: string,
+) {
+  return sql`(select ${column} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
 }
 
-async function getViewerRatingRow(
+// agg SET fragment — add each dimension's new score as a fresh contribution.
+function aggSumAdd(scores: RatingDimensionScores) {
+  return {
+    viewRatingSum: sql`${venueRatingAgg.viewRatingSum} + ${scores.view}`,
+    soundRatingSum: sql`${venueRatingAgg.soundRatingSum} + ${scores.sound}`,
+    amenitiesRatingSum: sql`${venueRatingAgg.amenitiesRatingSum} + ${scores.amenities}`,
+    transitRatingSum: sql`${venueRatingAgg.transitRatingSum} + ${scores.transit}`,
+  };
+}
+
+// agg SET fragment — move each dimension by (new - old) where old is read from
+// the rating row inside the batch (subquery), so the tally cannot drift.
+function aggSumDelta(
+  scores: RatingDimensionScores,
+  venueId: string,
+  ipHash: string,
+) {
+  return {
+    viewRatingSum: sql`${venueRatingAgg.viewRatingSum} + ${scores.view} - ${viewerColumn(venueRatings.viewScore, venueId, ipHash)}`,
+    soundRatingSum: sql`${venueRatingAgg.soundRatingSum} + ${scores.sound} - ${viewerColumn(venueRatings.soundScore, venueId, ipHash)}`,
+    amenitiesRatingSum: sql`${venueRatingAgg.amenitiesRatingSum} + ${scores.amenities} - ${viewerColumn(venueRatings.amenitiesScore, venueId, ipHash)}`,
+    transitRatingSum: sql`${venueRatingAgg.transitRatingSum} + ${scores.transit} - ${viewerColumn(venueRatings.transitScore, venueId, ipHash)}`,
+  };
+}
+
+// venue_ratings SET fragment — the dimensional scores plus the rounded legacy
+// mean (kept NOT NULL for rollback/export) and the change timestamp.
+function rowScoreSet(scores: RatingDimensionScores, now: number) {
+  return {
+    score: legacyMeanScore(scores),
+    viewScore: scores.view,
+    soundScore: scores.sound,
+    amenitiesScore: scores.amenities,
+    transitScore: scores.transit,
+    updatedAt: now,
+  };
+}
+
+/**
+ * This viewer's rating row (legacy or dimensional), or undefined when absent.
+ * The endpoint reads it ONCE to gate the daily cap, then hands it to
+ * {@link rateVenue} so the write path does not re-read the same row.
+ */
+export async function getViewerRatingRow(
   db: Db,
   venueId: string,
   ipHash: string,
@@ -82,15 +127,6 @@ async function getViewerRatingRow(
       )
       .limit(1)
   )[0];
-}
-
-/** Whether this viewer already has any rating row, legacy or dimensional. */
-export async function hasViewerRating(
-  db: Db,
-  venueId: string,
-  ipHash: string,
-): Promise<boolean> {
-  return (await getViewerRatingRow(db, venueId, ipHash)) !== undefined;
 }
 
 /** This viewer's complete dimensional score set, or null when absent/legacy. */
@@ -167,11 +203,7 @@ async function applyDimensionChange(
   scores: RatingDimensionScores,
   now: number,
 ): Promise<void> {
-  const oldView = sql`(select ${venueRatings.viewScore} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
-  const oldSound = sql`(select ${venueRatings.soundScore} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
-  const oldAmenities = sql`(select ${venueRatings.amenitiesScore} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
-  const oldTransit = sql`(select ${venueRatings.transitScore} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
-  const oldScore = sql`(select ${venueRatings.score} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
+  const oldScore = viewerColumn(venueRatings.score, venueId, ipHash);
   const score = legacyMeanScore(scores);
 
   await db.batch([
@@ -179,10 +211,7 @@ async function applyDimensionChange(
       .update(venueRatingAgg)
       .set({
         ratingSum: sql`${venueRatingAgg.ratingSum} + ${score} - ${oldScore}`,
-        viewRatingSum: sql`${venueRatingAgg.viewRatingSum} + ${scores.view} - ${oldView}`,
-        soundRatingSum: sql`${venueRatingAgg.soundRatingSum} + ${scores.sound} - ${oldSound}`,
-        amenitiesRatingSum: sql`${venueRatingAgg.amenitiesRatingSum} + ${scores.amenities} - ${oldAmenities}`,
-        transitRatingSum: sql`${venueRatingAgg.transitRatingSum} + ${scores.transit} - ${oldTransit}`,
+        ...aggSumDelta(scores, venueId, ipHash),
         updatedAt: now,
       })
       .where(
@@ -193,14 +222,7 @@ async function applyDimensionChange(
       ),
     db
       .update(venueRatings)
-      .set({
-        score,
-        viewScore: scores.view,
-        soundScore: scores.sound,
-        amenitiesScore: scores.amenities,
-        transitScore: scores.transit,
-        updatedAt: now,
-      })
+      .set(rowScoreSet(scores, now))
       .where(
         and(eq(venueRatings.venueId, venueId), eq(venueRatings.ipHash, ipHash)),
       ),
@@ -214,7 +236,7 @@ async function completeLegacyRating(
   scores: RatingDimensionScores,
   now: number,
 ): Promise<boolean> {
-  const oldScore = sql`(select ${venueRatings.score} from ${venueRatings} where ${venueRatings.venueId} = ${venueId} and ${venueRatings.ipHash} = ${ipHash})`;
+  const oldScore = viewerColumn(venueRatings.score, venueId, ipHash);
   const score = legacyMeanScore(scores);
 
   const [updatedAgg, updatedRating] = await db.batch([
@@ -223,10 +245,7 @@ async function completeLegacyRating(
       .set({
         ratingSum: sql`${venueRatingAgg.ratingSum} + ${score} - ${oldScore}`,
         dimensionRatingCount: sql`${venueRatingAgg.dimensionRatingCount} + 1`,
-        viewRatingSum: sql`${venueRatingAgg.viewRatingSum} + ${scores.view}`,
-        soundRatingSum: sql`${venueRatingAgg.soundRatingSum} + ${scores.sound}`,
-        amenitiesRatingSum: sql`${venueRatingAgg.amenitiesRatingSum} + ${scores.amenities}`,
-        transitRatingSum: sql`${venueRatingAgg.transitRatingSum} + ${scores.transit}`,
+        ...aggSumAdd(scores),
         updatedAt: now,
       })
       .where(
@@ -238,14 +257,7 @@ async function completeLegacyRating(
       .returning({ venueId: venueRatingAgg.venueId }),
     db
       .update(venueRatings)
-      .set({
-        score,
-        viewScore: scores.view,
-        soundScore: scores.sound,
-        amenitiesScore: scores.amenities,
-        transitScore: scores.transit,
-        updatedAt: now,
-      })
+      .set(rowScoreSet(scores, now))
       .where(
         and(
           eq(venueRatings.venueId, venueId),
@@ -275,12 +287,36 @@ async function completeLegacyOrApplyFreshChange(
   if (!freshScores) {
     throw new Error("legacy rating completion lost its guarded write");
   }
-  if (sameScores(freshScores, scores)) {
+  if (sameRatingScores(freshScores, scores)) {
     return "unchanged";
   }
 
   await applyDimensionChange(db, venueId, ipHash, scores, now);
   return "updated";
+}
+
+/**
+ * Dispatch for a viewer who ALREADY has a rating row, given their current
+ * scores (already read by the caller — no extra round trip). One path shared by
+ * the normal change flow and the UNIQUE-collision retry:
+ *   • complete dimensional & identical → idempotent no-op (`unchanged`)
+ *   • complete dimensional & different → delta change (`updated`)
+ *   • legacy (no dimensions)           → complete it / retry (`updated`/`unchanged`)
+ */
+async function changeExistingRating(
+  db: Db,
+  venueId: string,
+  ipHash: string,
+  scores: RatingDimensionScores,
+  existingScores: RatingDimensionScores | null,
+  now: number,
+): Promise<"updated" | "unchanged"> {
+  if (existingScores) {
+    if (sameRatingScores(existingScores, scores)) return "unchanged";
+    await applyDimensionChange(db, venueId, ipHash, scores, now);
+    return "updated";
+  }
+  return completeLegacyOrApplyFreshChange(db, venueId, ipHash, scores, now);
 }
 
 /**
@@ -293,9 +329,16 @@ export async function rateVenue(
   venueId: string,
   ipHash: string,
   scores: RatingDimensionScores,
-  now: number = Date.now(),
+  options: { now?: number; existingRow?: ViewerRatingRow } = {},
 ): Promise<RateVenueOutcome> {
-  const existing = await getViewerRatingRow(db, venueId, ipHash);
+  const now = options.now ?? Date.now();
+  // The endpoint already read this row to gate the daily cap; reuse it instead
+  // of a second SELECT of the same (venue_id, ip_hash). `"existingRow" in opts`
+  // distinguishes "caller knows there is no row" from "caller didn't read".
+  const existing =
+    "existingRow" in options
+      ? options.existingRow
+      : await getViewerRatingRow(db, venueId, ipHash);
   const existingScores = rowToScores(existing);
   const score = legacyMeanScore(scores);
 
@@ -332,52 +375,36 @@ export async function rateVenue(
               ratingCount: sql`${venueRatingAgg.ratingCount} + 1`,
               ratingSum: sql`${venueRatingAgg.ratingSum} + ${score}`,
               dimensionRatingCount: sql`${venueRatingAgg.dimensionRatingCount} + 1`,
-              viewRatingSum: sql`${venueRatingAgg.viewRatingSum} + ${scores.view}`,
-              soundRatingSum: sql`${venueRatingAgg.soundRatingSum} + ${scores.sound}`,
-              amenitiesRatingSum: sql`${venueRatingAgg.amenitiesRatingSum} + ${scores.amenities}`,
-              transitRatingSum: sql`${venueRatingAgg.transitRatingSum} + ${scores.transit}`,
+              ...aggSumAdd(scores),
               updatedAt: now,
             },
           }),
       ]);
       return { status: "created", ...(await readAgg(db, venueId)) };
     } catch (err) {
+      // Only a UNIQUE collision (a concurrent first rating from the same
+      // ip_hash) falls through to the change path; real D1 failures re-throw.
       if (!String(err).includes("UNIQUE")) throw err;
       const freshScores = await getViewerScores(db, venueId, ipHash);
-      if (freshScores && sameScores(freshScores, scores)) {
-        return { status: "unchanged", ...(await readAgg(db, venueId)) };
-      }
-      if (freshScores) {
-        await applyDimensionChange(db, venueId, ipHash, scores, now);
-        return { status: "updated", ...(await readAgg(db, venueId)) };
-      } else {
-        const status = await completeLegacyOrApplyFreshChange(
-          db,
-          venueId,
-          ipHash,
-          scores,
-          now,
-        );
-        return { status, ...(await readAgg(db, venueId)) };
-      }
+      const status = await changeExistingRating(
+        db,
+        venueId,
+        ipHash,
+        scores,
+        freshScores,
+        now,
+      );
+      return { status, ...(await readAgg(db, venueId)) };
     }
   }
 
-  if (!existingScores) {
-    const status = await completeLegacyOrApplyFreshChange(
-      db,
-      venueId,
-      ipHash,
-      scores,
-      now,
-    );
-    return { status, ...(await readAgg(db, venueId)) };
-  }
-
-  if (sameScores(existingScores, scores)) {
-    return { status: "unchanged", ...(await readAgg(db, venueId)) };
-  }
-
-  await applyDimensionChange(db, venueId, ipHash, scores, now);
-  return { status: "updated", ...(await readAgg(db, venueId)) };
+  const status = await changeExistingRating(
+    db,
+    venueId,
+    ipHash,
+    scores,
+    existingScores,
+    now,
+  );
+  return { status, ...(await readAgg(db, venueId)) };
 }


### PR DESCRIPTION
## Summary
- split venue ratings into four dimensions with legacy overall compatibility
- add migration/schema/server/API/client support for dimension scores
- update venue rating UI copy and rating tests for dimension averages and optimistic updates

## Tests
- npm test