### PR TITLE
feat(venue): show photo counts near title

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -42,6 +42,8 @@ const en: Messages = {
     country: "Japan",
     breadcrumbLabel: "Breadcrumb",
     subMapTabsLabel: "Switch seating chart",
+    photoCountSingle: "{count} photos total",
+    photoCountMulti: "Current area {subMapCount}, whole venue {venueCount}",
     notFoundTitle: "We haven't collected this venue yet.",
     notFoundBody: "Want to look at other venues from the home page?",
     backHome: "Back to home",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -37,6 +37,8 @@ const ja: Messages = {
     country: "日本",
     breadcrumbLabel: "パンくず",
     subMapTabsLabel: "座席図を切り替え",
+    photoCountSingle: "全 {count} 枚",
+    photoCountMulti: "現在のエリア {subMapCount} 枚、会場全体 {venueCount} 枚",
     notFoundTitle: "この会場はまだ収録されていません。",
     notFoundBody: "トップから他の会場を探してみますか？",
     backHome: "ホームへ",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -41,6 +41,8 @@ const ko: Messages = {
     country: "일본",
     breadcrumbLabel: "탐색 경로",
     subMapTabsLabel: "좌석도 전환",
+    photoCountSingle: "총 {count}장",
+    photoCountMulti: "현재 구역 {subMapCount}장, 전체 공연장 {venueCount}장",
     notFoundTitle: "이 회장은 아직 수록하지 않았어요.",
     notFoundBody: "홈에서 다른 회장을 둘러볼까요?",
     backHome: "홈으로",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -41,6 +41,8 @@ export interface Messages {
     /** Breadcrumb `<nav>` aria-label. */
     breadcrumbLabel: string;
     subMapTabsLabel: string;
+    photoCountSingle: string;
+    photoCountMulti: string;
     notFoundTitle: string;
     notFoundBody: string;
     backHome: string;
@@ -584,6 +586,8 @@ const zh: Messages = {
     country: "日本",
     breadcrumbLabel: "面包屑",
     subMapTabsLabel: "切换坐席图",
+    photoCountSingle: "共 {count} 张",
+    photoCountMulti: "当前区域 {subMapCount} 张，全场馆 {venueCount} 张",
     notFoundTitle: "这个场馆我们还没收录。",
     notFoundBody: "要不去首页看看其他场馆？",
     backHome: "回到首页",

--- a/src/islands/VenueMain.tsx
+++ b/src/islands/VenueMain.tsx
@@ -10,6 +10,7 @@ import {
   type SubMapChangeDetail,
 } from "@/lib/submap";
 import type { PhotoDto } from "@/lib/photos";
+import { dispatchPhotoCountChange } from "@/lib/photos";
 import { fetchSubMapPhotos } from "@/lib/photos-client";
 import Seatmap from "@/islands/Seatmap.tsx";
 import PhotoGrid, { type OpenSequencePayload } from "@/islands/PhotoGrid.tsx";
@@ -111,6 +112,11 @@ export default function VenueMain({
           if (!isCurrentRequest()) return;
           setPhotos(next);
           setPhotosSubMapId(subMapId);
+          dispatchPhotoCountChange({
+            venueId: venue.id,
+            subMapId,
+            count: next.length,
+          });
           setPhotosError(false);
           photosRequestRef.current = null;
           setPhotosLoading(false);
@@ -212,6 +218,11 @@ export default function VenueMain({
     setPhotos((prev) =>
       prev.some((p) => p.id === photo.id) ? prev : [photo, ...prev],
     );
+    dispatchPhotoCountChange({
+      venueId: photo.venueId,
+      subMapId: photo.subMapId,
+      delta: 1,
+    });
     setGridRefreshKey((k) => k + 1);
   }, []);
 

--- a/src/islands/VenuePhotoCountLine.tsx
+++ b/src/islands/VenuePhotoCountLine.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import type { Locale } from "@/i18n/config";
+import { useLocale } from "@/hooks/useLocale";
+import { fillTemplate } from "@/lib/format";
+import {
+  PHOTO_COUNT_CHANGE_EVENT,
+  type PhotoCountChangeDetail,
+  type VenuePhotoCountsDto,
+} from "@/lib/photos";
+import {
+  resolveInitialSubMapId,
+  SUBMAP_CHANGE_EVENT,
+  type SubMapChangeDetail,
+} from "@/lib/submap";
+import type { SubMap } from "@/types";
+
+interface VenuePhotoCountLineProps {
+  locale: Locale;
+  venueId: string;
+  subMaps: SubMap[];
+  initialSubMapId?: string;
+  initialCounts?: VenuePhotoCountsDto;
+}
+
+function replaceSubMapCount(
+  counts: VenuePhotoCountsDto,
+  subMapId: string,
+  count: number,
+): VenuePhotoCountsDto {
+  const nextCount = Math.max(0, count);
+  const previousCount = counts.bySubMapId[subMapId] ?? 0;
+  return {
+    total: Math.max(0, counts.total - previousCount + nextCount),
+    bySubMapId: { ...counts.bySubMapId, [subMapId]: nextCount },
+  };
+}
+
+function addSubMapCount(
+  counts: VenuePhotoCountsDto,
+  subMapId: string,
+  delta: number,
+): VenuePhotoCountsDto {
+  const previousCount = counts.bySubMapId[subMapId] ?? 0;
+  const nextCount = Math.max(0, previousCount + delta);
+  return {
+    total: Math.max(0, counts.total + nextCount - previousCount),
+    bySubMapId: { ...counts.bySubMapId, [subMapId]: nextCount },
+  };
+}
+
+export default function VenuePhotoCountLine({
+  locale,
+  venueId,
+  subMaps,
+  initialSubMapId,
+  initialCounts,
+}: VenuePhotoCountLineProps) {
+  const { t } = useLocale(locale);
+  const [activeSubMapId, setActiveSubMapId] = useState<string | undefined>(() =>
+    resolveInitialSubMapId(subMaps, initialSubMapId),
+  );
+  const [counts, setCounts] = useState<VenuePhotoCountsDto | undefined>(
+    initialCounts,
+  );
+
+  useEffect(() => {
+    function onSubMapChange(event: Event) {
+      const detail = (event as CustomEvent<SubMapChangeDetail>).detail;
+      if (detail?.subMapId) setActiveSubMapId(detail.subMapId);
+    }
+
+    window.addEventListener(SUBMAP_CHANGE_EVENT, onSubMapChange);
+    return () =>
+      window.removeEventListener(SUBMAP_CHANGE_EVENT, onSubMapChange);
+  }, []);
+
+  useEffect(() => {
+    function onPhotoCountChange(event: Event) {
+      const detail = (event as CustomEvent<PhotoCountChangeDetail>).detail;
+      if (!detail || detail.venueId !== venueId) return;
+      if (!Number.isFinite(detail.count) && !Number.isFinite(detail.delta)) {
+        return;
+      }
+
+      setCounts((current) => {
+        if (!current) return current;
+        if (detail.count !== undefined) {
+          return replaceSubMapCount(current, detail.subMapId, detail.count);
+        }
+        if (detail.delta !== undefined) {
+          return addSubMapCount(current, detail.subMapId, detail.delta);
+        }
+        return current;
+      });
+    }
+
+    window.addEventListener(PHOTO_COUNT_CHANGE_EVENT, onPhotoCountChange);
+    return () =>
+      window.removeEventListener(PHOTO_COUNT_CHANGE_EVENT, onPhotoCountChange);
+  }, [venueId]);
+
+  if (!counts) return null;
+
+  const activeCount = activeSubMapId
+    ? (counts.bySubMapId[activeSubMapId] ?? 0)
+    : 0;
+  const text =
+    subMaps.length <= 1
+      ? fillTemplate(t.venue.photoCountSingle, {
+          count: String(counts.total),
+        })
+      : fillTemplate(t.venue.photoCountMulti, {
+          subMapCount: String(activeCount),
+          venueCount: String(counts.total),
+        });
+
+  return (
+    <p className="text-muted-foreground mt-1 text-sm tabular-nums">{text}</p>
+  );
+}

--- a/src/lib/photos.ts
+++ b/src/lib/photos.ts
@@ -20,6 +20,32 @@ import type { PhotoRow } from "@/server/db/schema";
  */
 export type PhotoDto = Photo;
 
+/** Live photo counts for one venue, keyed by sub-map id. */
+export interface VenuePhotoCountsDto {
+  total: number;
+  bySubMapId: Record<string, number>;
+}
+
+export const PHOTO_COUNT_CHANGE_EVENT = "seatview:photo-count-change";
+
+export interface PhotoCountChangeDetail {
+  venueId: string;
+  subMapId: string;
+  /** Absolute live count for this sub-map. */
+  count?: number;
+  /** Delta to apply to this sub-map and the venue total. */
+  delta?: number;
+}
+
+export function dispatchPhotoCountChange(detail: PhotoCountChangeDetail): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<PhotoCountChangeDetail>(PHOTO_COUNT_CHANGE_EVENT, {
+      detail,
+    }),
+  );
+}
+
 /**
  * Map a raw D1 `photos` row to the client DTO. Drops server-only columns
  * (`ip_hash`, `deleted_at`) so they never reach the browser, and renames the

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -14,6 +14,7 @@ import VenueSearch from "@/islands/VenueSearch.tsx";
 import SubMapTabs from "@/islands/SubMapTabs.tsx";
 import VenueMain from "@/islands/VenueMain.tsx";
 import VenueComments from "@/islands/VenueComments.tsx";
+import VenuePhotoCountLine from "@/islands/VenuePhotoCountLine.tsx";
 import { asLocale } from "@/i18n/config";
 import { getMessages, venueName } from "@/i18n";
 import { getVenue } from "@/data/venues";
@@ -23,9 +24,9 @@ import { STORAGE_KEYS } from "@/lib/storage";
 import { env } from "cloudflare:workers";
 import { clientIp, hashIp } from "@/server/ip";
 import { getDb } from "@/server/db";
-import { listSubMapPhotos } from "@/server/photos";
+import { listSubMapPhotos, listVenuePhotoCounts } from "@/server/photos";
 import { getRatingSummary } from "@/server/ratings";
-import type { PhotoDto } from "@/lib/photos";
+import type { PhotoDto, VenuePhotoCountsDto } from "@/lib/photos";
 import { emptyRatingSums, type VenueRatingSummaryDto } from "@/lib/venue-rating";
 
 export const prerender = false;
@@ -61,6 +62,15 @@ if (venue && initialSubMapId && env.DB) {
     );
   } catch {
     initialPhotos = [];
+  }
+}
+
+let initialPhotoCounts: VenuePhotoCountsDto | undefined;
+if (venue && env.DB) {
+  try {
+    initialPhotoCounts = await listVenuePhotoCounts(getDb(env.DB), venue.id);
+  } catch {
+    initialPhotoCounts = undefined;
   }
 }
 
@@ -311,6 +321,14 @@ const giscusBacklink = venue
               <p class="text-muted-foreground mt-1 text-sm">
                 {venue.name_romaji}
               </p>
+              <VenuePhotoCountLine
+                locale={locale}
+                venueId={venue.id}
+                subMaps={venue.subMaps}
+                initialSubMapId={initialSubMapId}
+                initialCounts={initialPhotoCounts}
+                client:load
+              />
 
               {/* Comments + rating entry (task 06-10-giscus): a quiet demoted
                   chip, never a big star bar. Opens the drawer island. */}

--- a/src/server/photos.ts
+++ b/src/server/photos.ts
@@ -11,7 +11,11 @@
 import { and, desc, eq, gt, isNull, or, sql } from "drizzle-orm";
 import type { Db } from "@/server/db";
 import { photos, type NewPhotoRow, type PhotoRow } from "@/server/db/schema";
-import { rowToPhotoDto, type PhotoDto } from "@/lib/photos";
+import {
+  rowToPhotoDto,
+  type PhotoDto,
+  type VenuePhotoCountsDto,
+} from "@/lib/photos";
 import type { AdminPhotoDto, AdminPhotoVenueFacet } from "@/lib/admin";
 
 /**
@@ -61,6 +65,34 @@ export async function listSubMapPhotos(
 
   const rows = await base;
   return rows.map(rowToPhotoDto);
+}
+
+/**
+ * Live public photo counts for a venue, grouped by sub-map. Soft-deleted rows
+ * are excluded so the title-area count matches the public seatmap and grid.
+ */
+export async function listVenuePhotoCounts(
+  db: Db,
+  venueId: string,
+): Promise<VenuePhotoCountsDto> {
+  const rows = await db
+    .select({
+      subMapId: photos.subMapId,
+      count: sql<number>`count(*)`,
+    })
+    .from(photos)
+    .where(and(eq(photos.venueId, venueId), isNull(photos.deletedAt)))
+    .groupBy(photos.subMapId);
+
+  const bySubMapId: Record<string, number> = {};
+  let total = 0;
+  for (const row of rows) {
+    const count = Number(row.count);
+    bySubMapId[row.subMapId] = count;
+    total += count;
+  }
+
+  return { total, bySubMapId };
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a quiet venue title photo-count line for single-map and multi-map venues
- read live photo counts with a fail-soft D1 aggregate query
- keep counts synced on sub-map switches and successful uploads
- localize count copy for zh, ja, en, and ko

## Verification
- npm run format:check
- npm run typecheck
- npm test
- npm run build
- browser check: desktop + 390px mobile title area, single-map and multi-map venues, sub-map switch