### PR TITLE
feat(lightbox): shareable photo deep links

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -191,6 +191,11 @@ const en: Messages = {
     imageError: "This photo can't open right now",
     imageAlt: "View from {label} {date} {event}",
     position: "{n} / {total}",
+    share: "Share this view",
+    shareCopied: "Link copied",
+    shareText: "I found a great view at {venue}: {url} — come take a look!",
+    shareTextWithRegion:
+      "I found a great view in {region} at {venue}: {url} — come take a look!",
     correction: {
       open: "Request seat-label correction",
       title: "Seat-label correction",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -183,6 +183,11 @@ const ja: Messages = {
     imageError: "この写真は今読み込めません",
     imageAlt: "{label} {date} {event} の視点",
     position: "{n} / {total}",
+    share: "この視点をシェア",
+    shareCopied: "リンクをコピーしました",
+    shareText: "{venue}でいい視点を見つけました：{url} ぜひ見てみてください！",
+    shareTextWithRegion:
+      "{venue}の{region}でいい視点を見つけました：{url} ぜひ見てみてください！",
     correction: {
       open: "座席名の修正を送る",
       title: "座席名の修正",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -189,6 +189,11 @@ const ko: Messages = {
     imageError: "이 사진은 지금 열 수 없어요",
     imageAlt: "{label} {date} {event}의 시점",
     position: "{n} / {total}",
+    share: "이 시야 공유하기",
+    shareCopied: "링크가 복사되었습니다",
+    shareText: "{venue}에서 멋진 시야를 발견했어요: {url} 보러 오세요!",
+    shareTextWithRegion:
+      "{venue} {region}에서 멋진 시야를 발견했어요: {url} 보러 오세요!",
     correction: {
       open: "좌석명 수정 요청",
       title: "좌석명 수정",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -228,6 +228,14 @@ export interface Messages {
     imageAlt: string;
     /** `{n}` / `{total}` → 1-based position and count (sequence mode). */
     position: string;
+    /** Share button aria-label / title (footer strip). */
+    share: string;
+    /** In-place confirmation shown after the share link is copied. */
+    shareCopied: string;
+    /** Share blurb for a single-map venue. `{venue}` → name, `{url}` → link. */
+    shareText: string;
+    /** Share blurb with region. `{venue}` / `{region}` / `{url}`. */
+    shareTextWithRegion: string;
     /** Anonymous seat-label correction request, shown inside the detail sheet. */
     correction: {
       open: string;
@@ -731,6 +739,11 @@ const zh: Messages = {
     imageError: "这张照片暂时打不开",
     imageAlt: "{label} {date} {event} 的视角",
     position: "{n} / {total}",
+    share: "分享这个视角",
+    shareCopied: "链接已复制",
+    shareText: "我在{venue}发现了一个不错的视角：{url}，你也来看看吧！",
+    shareTextWithRegion:
+      "我在{venue}的{region}发现了一个不错的视角：{url}，你也来看看吧！",
     correction: {
       open: "提交座席名修改请求",
       title: "座席名修改",

--- a/src/islands/SeatViewLightbox.tsx
+++ b/src/islands/SeatViewLightbox.tsx
@@ -5,7 +5,7 @@ import Lightbox, {
 } from "yet-another-react-lightbox";
 import Zoom from "yet-another-react-lightbox/plugins/zoom";
 import "yet-another-react-lightbox/styles.css";
-import { ChevronLeft, ChevronRight, ChevronUp, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, ChevronUp, Share2, X } from "lucide-react";
 import type { Locale } from "@/i18n/config";
 import { useLocale } from "@/hooks/useLocale";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
@@ -25,6 +25,14 @@ import {
   relativeTime,
 } from "@/lib/format";
 import { cn } from "@/lib/utils";
+import type { Venue } from "@/types";
+import { subMapLabel, venueName } from "@/i18n";
+import {
+  buildShareText,
+  buildShareUrl,
+  copyToClipboard,
+  setPhotoIdInUrl,
+} from "@/lib/share";
 
 // Lightbox island (R3.7 + R3.9, shape-lightbox.md).
 //
@@ -61,6 +69,8 @@ export interface LightboxRequest {
 
 interface SeatViewLightboxProps {
   locale: Locale;
+  /** Owning venue — used to build share links + the locale-aware share blurb. */
+  venue: Venue;
   /** Active request (null = closed). VenueMain owns this state. */
   request: LightboxRequest | null;
   /** Called when the user closes the lightbox (Esc / ✕ / backdrop / swipe). */
@@ -99,6 +109,7 @@ function toSlide(dto: PhotoDto, locale: Locale, altTmpl: string): SeatSlide {
 
 export default function SeatViewLightbox({
   locale,
+  venue,
   request,
   onClose,
 }: SeatViewLightboxProps) {
@@ -112,6 +123,9 @@ export default function SeatViewLightbox({
   const [detailOpen, setDetailOpen] = useState(false);
   const [correctionOpen, setCorrectionOpen] = useState(false);
   const graceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Which photo currently shows the "copied" confirmation, + its auto-reset timer.
+  const [copiedPhotoId, setCopiedPhotoId] = useState<string | null>(null);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const open = request !== null;
   const mode = request?.mode ?? "single";
@@ -133,12 +147,16 @@ export default function SeatViewLightbox({
     setDetailOpen(false);
     setCorrectionOpen(false);
     const startPhoto = request.photos[request.index];
-    if (startPhoto) setSelectedPhoto(startPhoto.id);
+    if (startPhoto) {
+      setSelectedPhoto(startPhoto.id);
+      setPhotoIdInUrl(startPhoto.id);
+    }
   }, [request]);
 
   useEffect(
     () => () => {
       if (graceTimerRef.current) clearTimeout(graceTimerRef.current);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
     },
     [],
   );
@@ -153,7 +171,10 @@ export default function SeatViewLightbox({
       setDetailOpen(false);
       setCorrectionOpen(false);
       const photo = photos[index];
-      if (photo) setSelectedPhoto(photo.id);
+      if (photo) {
+        setSelectedPhoto(photo.id);
+        setPhotoIdInUrl(photo.id);
+      }
     },
     [photos],
   );
@@ -185,10 +206,37 @@ export default function SeatViewLightbox({
     } else {
       setSelectedPhoto(null);
     }
+    setPhotoIdInUrl(null);
     setDetailOpen(false);
     setCorrectionOpen(false);
     onClose();
   }, [photos, currentIndex, mode, reducedMotion, onClose]);
+
+  // Share the current photo: copy "<blurb> <canonical link>" to the clipboard and
+  // flash an in-place "copied" confirmation. The link is photoId-authoritative
+  // (`?tab=&photo=`), so it survives a sub-map rename. The region clause appears
+  // only when the venue actually has multiple sub-maps (single-map "全场" drops it).
+  const handleShare = useCallback(
+    async (dto: PhotoDto) => {
+      const subMap = venue.subMaps.find((s) => s.id === dto.subMapId);
+      const url = buildShareUrl(locale, venue.id, dto.subMapId, dto.id);
+      const region =
+        venue.subMaps.length > 1 && subMap ? subMapLabel(subMap, locale) : null;
+      const text = buildShareText(
+        {
+          withRegion: t.lightbox.shareTextWithRegion,
+          withoutRegion: t.lightbox.shareText,
+        },
+        { venue: venueName(venue, locale), region, url },
+      );
+      const ok = await copyToClipboard(text);
+      if (!ok) return;
+      setCopiedPhotoId(dto.id);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = setTimeout(() => setCopiedPhotoId(null), 2000);
+    },
+    [venue, locale, t.lightbox.shareText, t.lightbox.shareTextWithRegion],
+  );
 
   // Esc priority: when the detail sheet is open, Esc closes the SHEET, not the
   // Lightbox (shape §7). If the correction panel is nested inside it, Esc closes
@@ -299,6 +347,10 @@ export default function SeatViewLightbox({
               }
               openDetailsLabel={t.lightbox.openDetails}
               onOpenDetails={() => setDetailOpen(true)}
+              shareLabel={t.lightbox.share}
+              shareCopiedLabel={t.lightbox.shareCopied}
+              copied={copiedPhotoId === dto.id}
+              onShare={handleShare}
             />
           );
         },
@@ -341,6 +393,10 @@ interface FooterStripProps {
   position: string | null;
   openDetailsLabel: string;
   onOpenDetails: () => void;
+  shareLabel: string;
+  shareCopiedLabel: string;
+  copied: boolean;
+  onShare: (dto: PhotoDto) => void;
 }
 
 /**
@@ -356,6 +412,10 @@ function FooterStrip({
   position,
   openDetailsLabel,
   onOpenDetails,
+  shareLabel,
+  shareCopiedLabel,
+  copied,
+  onShare,
 }: FooterStripProps) {
   const date = performanceDate(dto.performanceDate, locale);
   return (
@@ -387,14 +447,40 @@ function FooterStrip({
           )}
         </span>
       </button>
-      {isSequence && position && (
-        <span
-          className="pointer-events-none rounded px-1.5 py-0.5 text-xs text-[oklch(0.8_0.006_86)] [font-variant-numeric:tabular-nums]"
-          aria-hidden="true"
+      <div className="flex shrink-0 items-center gap-2">
+        {isSequence && position && (
+          <span
+            className="pointer-events-none rounded px-1.5 py-0.5 text-xs text-[oklch(0.8_0.006_86)] [font-variant-numeric:tabular-nums]"
+            aria-hidden="true"
+          >
+            {position}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => onShare(dto)}
+          aria-label={shareLabel}
+          title={shareLabel}
+          className={cn(
+            "pointer-events-auto inline-flex items-center gap-1.5 rounded-full text-sm",
+            copied ? "py-1 pl-2.5 pr-3" : "p-2",
+            "border border-[oklch(0.8_0.006_86_/_0.25)] bg-[oklch(0.13_0.008_75_/_0.6)] text-[oklch(0.93_0.006_88)]",
+            "transition-colors hover:border-[oklch(0.8_0.006_86_/_0.45)] hover:bg-[oklch(0.16_0.008_75_/_0.72)]",
+            "focus-visible:outline focus-visible:outline-2 focus-visible:outline-[oklch(0.8_0.006_86)] focus:outline-none",
+          )}
         >
-          {position}
-        </span>
-      )}
+          <Share2
+            className="size-3.5 shrink-0"
+            aria-hidden="true"
+            strokeWidth={1.5}
+          />
+          {copied && (
+            <span aria-live="polite" className="whitespace-nowrap">
+              {shareCopiedLabel}
+            </span>
+          )}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/islands/SubMapTabs.tsx
+++ b/src/islands/SubMapTabs.tsx
@@ -5,7 +5,9 @@ import type { SubMap } from "@/types";
 import {
   resolveInitialSubMapId,
   setActiveSubMap,
+  SUBMAP_CHANGE_EVENT,
   SUBMAP_QUERY_PARAM,
+  type SubMapChangeDetail,
 } from "@/lib/submap";
 import { cn } from "@/lib/utils";
 
@@ -45,6 +47,18 @@ export default function SubMapTabs({
     const resolved = resolveInitialSubMapId(subMaps, requested);
     if (resolved) setActive(resolved);
   }, [subMaps]);
+
+  // Follow programmatic sub-map changes (e.g. a share deep link auto-opening a
+  // photo whose sub-map differs from a stale/renamed `?tab=`) so the underline
+  // stays in sync, not just on mount or local click.
+  useEffect(() => {
+    function onChange(event: Event) {
+      const detail = (event as CustomEvent<SubMapChangeDetail>).detail;
+      if (detail?.subMapId) setActive(detail.subMapId);
+    }
+    window.addEventListener(SUBMAP_CHANGE_EVENT, onChange);
+    return () => window.removeEventListener(SUBMAP_CHANGE_EVENT, onChange);
+  }, []);
 
   if (subMaps.length <= 1) return null;
 

--- a/src/islands/VenueMain.tsx
+++ b/src/islands/VenueMain.tsx
@@ -6,6 +6,7 @@ import { useSelectedPhoto } from "@/hooks/useSelectedPhoto";
 import type { Venue } from "@/types";
 import {
   resolveInitialSubMapId,
+  setActiveSubMap,
   SUBMAP_CHANGE_EVENT,
   type SubMapChangeDetail,
 } from "@/lib/submap";
@@ -30,6 +31,11 @@ interface VenueMainProps {
    * GET /api/photos.
    */
   initialPhotos?: PhotoDto[];
+  /**
+   * Photo id from a `?photo=` share deep link (resolved + validated SSR). When
+   * set, the lightbox auto-opens this photo (single mode) once on mount.
+   */
+  initialOpenPhotoId?: string;
 }
 
 /** First grid batch size (mirrors PhotoGrid's GRID_BATCH); used to decide the
@@ -55,6 +61,7 @@ export default function VenueMain({
   venue,
   initialSubMapId,
   initialPhotos = [],
+  initialOpenPhotoId,
 }: VenueMainProps) {
   const { t } = useLocale(locale);
 
@@ -194,6 +201,23 @@ export default function VenueMain({
 
   const handleCloseLightbox = useCallback(() => setLightboxRequest(null), []);
 
+  // Share deep link: open the linked photo once on mount (single mode — "look at
+  // THIS view"). SSR aligned the initial sub-map to the photo's, so it is already
+  // in `initialPhotos`. The ref guards against re-opening after the user closes.
+  const didOpenInitialRef = useRef(false);
+  useEffect(() => {
+    if (didOpenInitialRef.current || !initialOpenPhotoId) return;
+    const photo = initialPhotos.find((p) => p.id === initialOpenPhotoId);
+    if (!photo) return;
+    didOpenInitialRef.current = true;
+    // Canonicalize `?tab=` to the linked photo's sub-map so a stale/renamed tab
+    // self-heals in the tabs UI too — the SSR already aligned the seatmap/grid,
+    // but SubMapTabs reads `?tab=` from the URL. Multi-map venues only (single-
+    // map venues render no tabs). Broadcasts so the tabs underline follows.
+    if (venue.subMaps.length > 1) setActiveSubMap(photo.subMapId);
+    setLightboxRequest({ mode: "single", photos: [photo], index: 0 });
+  }, [initialOpenPhotoId, initialPhotos, venue.subMaps]);
+
   // ── Upload Sheet (step 6, shape-upload-sheet.md) ───────────────────────────
   // The upload is always attributed to the CURRENT active sub-map (R4.2 —
   // transparent to the user, no explicit picker). Both the upload button below
@@ -300,6 +324,7 @@ export default function VenueMain({
 
       <SeatViewLightbox
         locale={locale}
+        venue={venue}
         request={lightboxRequest}
         onClose={handleCloseLightbox}
       />

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,108 @@
+// Photo deep-link + share helpers.
+//
+// A photo's canonical share link carries the photo ULID in the query
+// (`?photo=<id>`), alongside the existing `?tab=<sub-map>` (src/lib/submap.ts).
+// The ULID alone resolves venue + sub-map server-side, so a shared link still
+// opens after a sub-map rename (the same "rename never breaks links" rationale
+// as `?tab=`, prd.md routing design). `tab` is kept only for readability and as
+// a graceful fallback when the photo is gone.
+
+import type { Locale } from "@/i18n/config";
+import { fillTemplate } from "@/lib/format";
+import { SUBMAP_QUERY_PARAM } from "@/lib/submap";
+
+export const PHOTO_QUERY_PARAM = "photo";
+
+/** Canonical site origin for share links (prod = https://seat.genchi.top),
+ *  falling back to the live origin on the client. */
+function shareOrigin(): string {
+  const configured = import.meta.env.PUBLIC_SITE_URL as string | undefined;
+  if (configured) return configured.replace(/\/+$/, "");
+  if (typeof window !== "undefined") return window.location.origin;
+  return "https://seat.genchi.top";
+}
+
+/** Build the canonical share URL for one photo (current viewing locale). */
+export function buildShareUrl(
+  locale: Locale,
+  venueId: string,
+  subMapId: string,
+  photoId: string,
+): string {
+  const url = new URL(`/${locale}/v/${venueId}`, shareOrigin());
+  url.searchParams.set(SUBMAP_QUERY_PARAM, subMapId);
+  url.searchParams.set(PHOTO_QUERY_PARAM, photoId);
+  return url.toString();
+}
+
+export interface ShareTextTemplates {
+  /** `{venue}` + `{region}` + `{url}` — used when the venue has real sub-maps. */
+  withRegion: string;
+  /** `{venue}` + `{url}` — used for single-map ("全场") venues. */
+  withoutRegion: string;
+}
+
+/** Compose the share blurb. `region` null → drop the region clause entirely. */
+export function buildShareText(
+  templates: ShareTextTemplates,
+  opts: { venue: string; region: string | null; url: string },
+): string {
+  if (opts.region) {
+    return fillTemplate(templates.withRegion, {
+      venue: opts.venue,
+      region: opts.region,
+      url: opts.url,
+    });
+  }
+  return fillTemplate(templates.withoutRegion, {
+    venue: opts.venue,
+    url: opts.url,
+  });
+}
+
+/** Read a photo id from a URL's query, if present. */
+export function readPhotoIdFromUrl(url: URL): string | undefined {
+  return url.searchParams.get(PHOTO_QUERY_PARAM) ?? undefined;
+}
+
+/**
+ * Reflect the currently-open photo in the address bar (no reload, no history
+ * entry) so the bare URL stays shareable / reloadable. Pass null to clear it on
+ * close. Client-only; mirrors `setActiveSubMap`'s replaceState approach.
+ */
+export function setPhotoIdInUrl(photoId: string | null): void {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (photoId) url.searchParams.set(PHOTO_QUERY_PARAM, photoId);
+  else url.searchParams.delete(PHOTO_QUERY_PARAM);
+  window.history.replaceState(null, "", url.toString());
+}
+
+/**
+ * Copy text to the clipboard with a legacy fallback for non-secure contexts /
+ * older browsers. Returns whether the copy succeeded.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    /* fall through to the legacy path */
+  }
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -20,11 +20,16 @@ import { getMessages, venueName } from "@/i18n";
 import { getVenue } from "@/data/venues";
 import { getPrefecture, prefectureName } from "@/data/prefectures";
 import { readSubMapFromUrl, resolveInitialSubMapId } from "@/lib/submap";
+import { readPhotoIdFromUrl } from "@/lib/share";
 import { STORAGE_KEYS } from "@/lib/storage";
 import { env } from "cloudflare:workers";
 import { clientIp, hashIp } from "@/server/ip";
 import { getDb } from "@/server/db";
-import { listSubMapPhotos, listVenuePhotoCounts } from "@/server/photos";
+import {
+  getPhotoById,
+  listSubMapPhotos,
+  listVenuePhotoCounts,
+} from "@/server/photos";
 import { getRatingSummary } from "@/server/ratings";
 import type { PhotoDto, VenuePhotoCountsDto } from "@/lib/photos";
 import { emptyRatingSums, type VenueRatingSummaryDto } from "@/lib/venue-rating";
@@ -43,8 +48,34 @@ const venue = venueId ? getVenue(venueId) : undefined;
 const requestedSubMapId = venue
   ? readSubMapFromUrl(Astro.url, venue.subMaps)
   : undefined;
+
+// Share deep link (`?photo=<ulid>`): the photo ULID is authoritative — look it
+// up to derive its (possibly renamed) sub-map so a shared link still opens even
+// when `?tab=` is stale or missing. Soft-deleted / cross-venue / unknown ids are
+// ignored (the page renders without auto-opening). Runs only when `?photo=` is
+// present — one primary-key read, fails soft.
+const requestedPhotoId = venue ? readPhotoIdFromUrl(Astro.url) : undefined;
+let initialOpenPhotoId: string | undefined;
+let deepLinkSubMapId: string | undefined;
+if (venue && requestedPhotoId && env.DB) {
+  try {
+    const photo = await getPhotoById(getDb(env.DB), requestedPhotoId);
+    if (
+      photo &&
+      photo.venueId === venue.id &&
+      venue.subMaps.some((s) => s.id === photo.subMapId)
+    ) {
+      initialOpenPhotoId = photo.id;
+      deepLinkSubMapId = photo.subMapId;
+    }
+  } catch {
+    // Fail soft: a deep-link lookup error never breaks the page.
+  }
+}
+
+// Deep-link sub-map (from `?photo=`) wins over `?tab=` so a stale tab self-heals.
 const initialSubMapId = venue
-  ? resolveInitialSubMapId(venue.subMaps, requestedSubMapId)
+  ? resolveInitialSubMapId(venue.subMaps, deepLinkSubMapId ?? requestedSubMapId)
   : undefined;
 
 // SSR-query the initial sub-map's annotation points (R3.4) so the seatmap's
@@ -356,6 +387,7 @@ const giscusBacklink = venue
                   venue={venue}
                   initialSubMapId={initialSubMapId}
                   initialPhotos={initialPhotos}
+                  initialOpenPhotoId={initialOpenPhotoId}
                   client:load
                 />
               </div>

--- a/src/server/photos.ts
+++ b/src/server/photos.ts
@@ -68,6 +68,27 @@ export async function listSubMapPhotos(
 }
 
 /**
+ * Look up one LIVE photo by id for share deep-link resolution. The ULID alone
+ * is authoritative: the venue page reads it to derive the photo's (possibly
+ * renamed) sub-map so a shared `?photo=` link still opens even when `?tab=` is
+ * stale or absent. Soft-deleted rows return null so a link to a removed photo
+ * just renders the venue without auto-opening. Single primary-key read; only
+ * runs when the page is hit with `?photo=`.
+ */
+export async function getPhotoById(
+  db: Db,
+  id: string,
+): Promise<PhotoDto | null> {
+  const rows = await db
+    .select()
+    .from(photos)
+    .where(and(eq(photos.id, id), isNull(photos.deletedAt)))
+    .limit(1);
+  const row = rows[0];
+  return row ? rowToPhotoDto(row) : null;
+}
+
+/**
  * Live public photo counts for a venue, grouped by sub-map. Soft-deleted rows
  * are excluded so the title-area count matches the public seatmap and grid.
  */


### PR DESCRIPTION
## Summary
- Add per-photo share URLs with `?tab=&photo=<ulid>` and localized clipboard text.
- Resolve `?photo=` on SSR so stale or missing `?tab=` self-heals to the photo's real sub-map.
- Auto-open linked photos in single-mode lightbox and keep the address bar synced while browsing.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run format:check`
- Manual smoke: stale tab self-heals, cross-venue photo id does not open, single-map share copy omits region, close clears `photo`.