### PR TITLE
feat(lightbox): locate photos on seatmap

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -182,6 +182,7 @@ const en: Messages = {
   },
   lightbox: {
     close: "Close preview",
+    locate: "Locate on the seating chart",
     prev: "Previous photo",
     next: "Next photo",
     openDetails: "Open seat details",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -174,6 +174,7 @@ const ja: Messages = {
   },
   lightbox: {
     close: "プレビューを閉じる",
+    locate: "座席表で位置を表示",
     prev: "前の写真",
     next: "次の写真",
     openDetails: "座席詳細を開く",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -180,6 +180,7 @@ const ko: Messages = {
   },
   lightbox: {
     close: "미리보기 닫기",
+    locate: "좌석표에서 위치 보기",
     prev: "이전 사진",
     next: "다음 사진",
     openDetails: "좌석 상세 열기",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -212,6 +212,7 @@ export interface Messages {
   lightbox: {
     /** aria-labels / control titles. */
     close: string;
+    locate: string;
     prev: string;
     next: string;
     /** Footer strip: tap to open the metadata sheet. */
@@ -730,6 +731,7 @@ const zh: Messages = {
   },
   lightbox: {
     close: "关闭预览",
+    locate: "在坐席图中定位",
     prev: "上一张",
     next: "下一张",
     openDetails: "展开座位详情",

--- a/src/islands/SeatViewLightbox.tsx
+++ b/src/islands/SeatViewLightbox.tsx
@@ -5,7 +5,14 @@ import Lightbox, {
 } from "yet-another-react-lightbox";
 import Zoom from "yet-another-react-lightbox/plugins/zoom";
 import "yet-another-react-lightbox/styles.css";
-import { ChevronLeft, ChevronRight, ChevronUp, Share2, X } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  LocateFixed,
+  Share2,
+  X,
+} from "lucide-react";
 import type { Locale } from "@/i18n/config";
 import { useLocale } from "@/hooks/useLocale";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
@@ -75,6 +82,8 @@ interface SeatViewLightboxProps {
   request: LightboxRequest | null;
   /** Called when the user closes the lightbox (Esc / ✕ / backdrop / swipe). */
   onClose: () => void;
+  /** Locate the current photo on the seatmap and close this overlay. */
+  onLocate?: (photoId: string) => void;
 }
 
 const PUBLIC_R2_BASE_URL = import.meta.env.PUBLIC_R2_BASE_URL;
@@ -112,6 +121,7 @@ export default function SeatViewLightbox({
   venue,
   request,
   onClose,
+  onLocate,
 }: SeatViewLightboxProps) {
   const { t } = useLocale(locale);
   const reducedMotion = usePrefersReducedMotion();
@@ -238,6 +248,18 @@ export default function SeatViewLightbox({
     [venue, locale, t.lightbox.shareText, t.lightbox.shareTextWithRegion],
   );
 
+  const handleLocateCurrent = useCallback(() => {
+    if (!currentPhoto) return;
+    if (graceTimerRef.current) {
+      clearTimeout(graceTimerRef.current);
+      graceTimerRef.current = null;
+    }
+    setPhotoIdInUrl(null);
+    setDetailOpen(false);
+    setCorrectionOpen(false);
+    onLocate?.(currentPhoto.id);
+  }, [currentPhoto, onLocate]);
+
   // Esc priority: when the detail sheet is open, Esc closes the SHEET, not the
   // Lightbox (shape §7). If the correction panel is nested inside it, Esc closes
   // that panel first.
@@ -291,6 +313,25 @@ export default function SeatViewLightbox({
         Previous: t.lightbox.prev,
         Next: t.lightbox.next,
         Close: t.lightbox.close,
+      }}
+      toolbar={{
+        buttons: [
+          <button
+            key="locate"
+            type="button"
+            className="yarl__button"
+            aria-label={t.lightbox.locate}
+            title={t.lightbox.locate}
+            onClick={handleLocateCurrent}
+          >
+            <LocateFixed
+              className="size-6"
+              aria-hidden="true"
+              strokeWidth={1.25}
+            />
+          </button>,
+          "close",
+        ],
       }}
       // Ink overlay ~90%, no vermilion. Chrome (close / nav) is hairline-ash on
       // ink — quiet, never the SaaS-blue default and never the accent.

--- a/src/islands/Seatmap.tsx
+++ b/src/islands/Seatmap.tsx
@@ -12,7 +12,13 @@ import { useLocale } from "@/hooks/useLocale";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { useElementSize } from "@/hooks/useElementSize";
 import { setSelectedPhoto } from "@/lib/selected-photo";
-import { clusterPoints, layOutPoints, type Cluster } from "@/lib/cluster";
+import {
+  CLUSTER_TUNING,
+  clusterPoints,
+  layOutPoints,
+  type Cluster,
+  type LaidOutPoint,
+} from "@/lib/cluster";
 import { imageContentRect } from "@/lib/image-rect";
 import type { PhotoDto } from "@/lib/photos";
 import type { SubMap } from "@/types";
@@ -45,6 +51,14 @@ const CLUSTER_ZOOM_FACTOR = 2;
 const ZOOM_ANIM_MS = 400;
 /** Controls fade to 50% opacity after this idle window (shape §5). */
 const CONTROLS_IDLE_MS = 5000;
+/** Locate zoom floor: enough context to see where the pin sits on the map. */
+const LOCATE_MIN_SCALE = 2.5;
+/** Small safety margin so a clustered target reliably separates after zoom. */
+const LOCATE_SEPARATION_MARGIN = 1.15;
+/** One-shot pin pulse duration after locate zoom completes. */
+const LOCATE_PULSE_MS = 1200;
+/** Delay locate until yarl has released its no-scroll lock after closing. */
+const LOCATE_START_DELAY_MS = 50;
 
 interface SeatmapProps {
   locale: Locale;
@@ -57,6 +71,8 @@ interface SeatmapProps {
   error?: boolean;
   /** Currently selected photo id from the cross-island signal. */
   selectedPhotoId: string | null;
+  /** One-shot request to bring a lightbox photo back into view on the map. */
+  locateTarget?: { photoId: string; token: number } | null;
   /**
    * Mount point for step 5: clicking a single pin opens the Lightbox here.
    * Optional so the seatmap works standalone before the Lightbox lands.
@@ -73,6 +89,7 @@ export default function Seatmap({
   loading = false,
   error = false,
   selectedPhotoId,
+  locateTarget = null,
   onOpenLightbox,
   onRetry,
 }: SeatmapProps) {
@@ -80,6 +97,7 @@ export default function Seatmap({
   const reducedMotion = usePrefersReducedMotion();
 
   const transformRef = useRef<ReactZoomPanPinchContentRef>(null);
+  const seatmapFrameRef = useRef<HTMLDivElement | null>(null);
   const wrapperNodeRef = useRef<HTMLDivElement | null>(null);
   // Unscaled frame box (NOT the zoom/pan-transformed layer) → the object-contain
   // chart-image content rect that pins anchor to. Re-measured on resize.
@@ -99,6 +117,7 @@ export default function Seatmap({
 
   // Controls idle fade.
   const [controlsIdle, setControlsIdle] = useState(false);
+  const [locatePulseId, setLocatePulseId] = useState<string | null>(null);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const wakeControls = useCallback(() => {
@@ -176,6 +195,77 @@ export default function Seatmap({
     [scale, subMap.width, subMap.height, animTime, wakeControls],
   );
 
+  useEffect(() => {
+    if (!locateTarget) return;
+
+    let startTimer: ReturnType<typeof setTimeout> | null = null;
+    let pulseDelayTimer: ReturnType<typeof setTimeout> | null = null;
+    let pulseClearTimer: ReturnType<typeof setTimeout> | null = null;
+
+    startTimer = setTimeout(() => {
+      const frame = seatmapFrameRef.current;
+      frame?.scrollIntoView({
+        block: "center",
+        behavior: reducedMotion ? "auto" : "smooth",
+      });
+
+      const target = laidOut.find(
+        (point) => point.photo.id === locateTarget.photoId,
+      );
+      const api = transformRef.current;
+      const wrapper = wrapperNodeRef.current;
+      let pulseDelay = 0;
+
+      if (target && api && wrapper) {
+        const rect = wrapper.getBoundingClientRect();
+        const targetScale = locateScaleForPoint(target, laidOut);
+        const cr = imageContentRect(
+          rect.width,
+          rect.height,
+          subMap.width,
+          subMap.height,
+        );
+        const surfaceX = cr.offsetX + (target.x / subMap.width) * cr.width;
+        const surfaceY = cr.offsetY + (target.y / subMap.height) * cr.height;
+        const positionX = rect.width / 2 - surfaceX * targetScale;
+        const positionY = rect.height / 2 - surfaceY * targetScale;
+
+        api.setTransform(
+          positionX,
+          positionY,
+          targetScale,
+          animTime,
+          "easeOutQuart",
+        );
+        wakeControls();
+        pulseDelay = animTime;
+      }
+
+      pulseDelayTimer = setTimeout(() => {
+        setLocatePulseId(locateTarget.photoId);
+        pulseClearTimer = setTimeout(() => {
+          setLocatePulseId((current) =>
+            current === locateTarget.photoId ? null : current,
+          );
+        }, LOCATE_PULSE_MS);
+      }, pulseDelay);
+    }, LOCATE_START_DELAY_MS);
+
+    return () => {
+      if (startTimer) clearTimeout(startTimer);
+      if (pulseDelayTimer) clearTimeout(pulseDelayTimer);
+      if (pulseClearTimer) clearTimeout(pulseClearTimer);
+    };
+  }, [
+    animTime,
+    laidOut,
+    locateTarget,
+    reducedMotion,
+    subMap.height,
+    subMap.width,
+    wakeControls,
+  ]);
+
   const handlePinClick = useCallback(
     (photoId: string) => {
       // Emit the cross-island signal so the matching pin (and step-5 grid card)
@@ -192,7 +282,7 @@ export default function Seatmap({
   // errorBody). It fills the fixed-ratio seatmap frame; retry re-runs the fetch.
   if (error) {
     return (
-      <SeatmapFrame subMapId={subMap.id}>
+      <SeatmapFrame subMapId={subMap.id} frameRef={seatmapFrameRef}>
         <LoadFailure locale={locale} onRetry={() => onRetry?.()} fill />
       </SeatmapFrame>
     );
@@ -200,7 +290,7 @@ export default function Seatmap({
 
   if (!loading && photos.length === 0) {
     return (
-      <SeatmapFrame subMapId={subMap.id}>
+      <SeatmapFrame subMapId={subMap.id} frameRef={seatmapFrameRef}>
         <ChartImage subMap={subMap} locale={locale} dimmed />
         <div className="bg-background/55 absolute inset-0 flex flex-col items-center justify-center gap-1 px-6 text-center">
           <p className="text-foreground text-sm">{t.seatmap.emptyBody}</p>
@@ -211,7 +301,7 @@ export default function Seatmap({
   }
 
   return (
-    <SeatmapFrame subMapId={subMap.id}>
+    <SeatmapFrame subMapId={subMap.id} frameRef={seatmapFrameRef}>
       <div ref={setWrapperRef} className="absolute inset-0">
         <TransformWrapper
           ref={transformRef}
@@ -287,6 +377,7 @@ export default function Seatmap({
                         selected={
                           cluster.members[0]!.photo.id === selectedPhotoId
                         }
+                        pulse={cluster.members[0]!.photo.id === locatePulseId}
                         onActivate={() =>
                           handlePinClick(cluster.members[0]!.photo.id)
                         }
@@ -405,17 +496,49 @@ function fallbackFramePct(
   return ((cr.offsetY + fraction * cr.height) / FRAME_FALLBACK_HEIGHT) * 100;
 }
 
+function locateScaleForPoint(
+  target: LaidOutPoint,
+  points: readonly LaidOutPoint[],
+): number {
+  let nearest = Number.POSITIVE_INFINITY;
+  for (const point of points) {
+    if (point.photo.id === target.photo.id) continue;
+    const distance = Math.hypot(point.x - target.x, point.y - target.y);
+    if (distance < nearest) nearest = distance;
+  }
+
+  const deClusterScale =
+    nearest === 0
+      ? MAX_SCALE
+      : Number.isFinite(nearest)
+        ? Math.sqrt(CLUSTER_TUNING.BASE_THRESHOLD_PX / nearest) *
+          LOCATE_SEPARATION_MARGIN
+        : MIN_SCALE;
+
+  return clamp(
+    Math.max(LOCATE_MIN_SCALE, deClusterScale),
+    MIN_SCALE,
+    MAX_SCALE,
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
 /* ── Subcomponents ──────────────────────────────────────────────────────── */
 
 interface SeatmapFrameProps {
   subMapId: string;
   children: React.ReactNode;
+  frameRef?: React.Ref<HTMLDivElement>;
 }
 
 /** Outer surface: fixed 3:2 viewport, clipped, hairline border, no shadow. */
-function SeatmapFrame({ subMapId, children }: SeatmapFrameProps) {
+function SeatmapFrame({ subMapId, children, frameRef }: SeatmapFrameProps) {
   return (
     <div
+      ref={frameRef}
       className="border-border bg-card relative aspect-[3/2] w-full overflow-hidden rounded-md border"
       data-seatmap
       data-sub-map-id={subMapId}
@@ -454,6 +577,7 @@ interface PinProps {
   photo: PhotoDto;
   label: string;
   selected: boolean;
+  pulse?: boolean;
   onActivate: () => void;
 }
 
@@ -471,13 +595,13 @@ interface PinProps {
  * for an ink one, so the state reads without relying on hue (DESIGN.md
  * non-color-only rule).
  */
-function Pin({ photo, label, selected, onActivate }: PinProps) {
+function Pin({ photo, label, selected, pulse = false, onActivate }: PinProps) {
   return (
     <button
       type="button"
       // 44x44 touch target (transparent), centered on the visible ~14px marker.
       className={cn(
-        "group pointer-events-auto grid size-11 place-items-center rounded-full",
+        "group pointer-events-auto relative grid size-11 place-items-center rounded-full",
         "focus-visible:outline-none",
       )}
       aria-label={label}
@@ -485,6 +609,13 @@ function Pin({ photo, label, selected, onActivate }: PinProps) {
       data-photo-id={photo.id}
       onClick={onActivate}
     >
+      {pulse && (
+        <span
+          aria-hidden="true"
+          className="bg-accent/35 pointer-events-none absolute top-1/2 left-1/2 size-4 rounded-full"
+          style={{ animation: "seatview-locate-pulse 600ms ease-out 2" }}
+        />
+      )}
       <span
         className={cn(
           "block rounded-full transition-[transform,background-color,border-color] duration-150",

--- a/src/islands/VenueMain.tsx
+++ b/src/islands/VenueMain.tsx
@@ -13,6 +13,7 @@ import {
 import type { PhotoDto } from "@/lib/photos";
 import { dispatchPhotoCountChange } from "@/lib/photos";
 import { fetchSubMapPhotos } from "@/lib/photos-client";
+import { setSelectedPhoto } from "@/lib/selected-photo";
 import Seatmap from "@/islands/Seatmap.tsx";
 import PhotoGrid, { type OpenSequencePayload } from "@/islands/PhotoGrid.tsx";
 import SeatViewLightbox, {
@@ -41,6 +42,11 @@ interface VenueMainProps {
 /** First grid batch size (mirrors PhotoGrid's GRID_BATCH); used to decide the
  *  SSR `initialHasMore` probe from the full SSR point set. */
 const GRID_FIRST_BATCH = 24;
+
+interface LocateTarget {
+  photoId: string;
+  token: number;
+}
 
 /**
  * Venue main column below the title: seating chart + upload button + photo
@@ -177,6 +183,7 @@ export default function VenueMain({
   // ── Lightbox: one instance, two modes ─────────────────────────────────────
   const [lightboxRequest, setLightboxRequest] =
     useState<LightboxRequest | null>(null);
+  const [locateTarget, setLocateTarget] = useState<LocateTarget | null>(null);
 
   // Seatmap pin → SINGLE mode (look at this seat). The full point set lives in
   // `photos`; find the clicked one and open with just it (no paging).
@@ -200,6 +207,15 @@ export default function VenueMain({
   }, []);
 
   const handleCloseLightbox = useCallback(() => setLightboxRequest(null), []);
+
+  const handleLocatePhoto = useCallback((photoId: string) => {
+    setSelectedPhoto(photoId);
+    setLightboxRequest(null);
+    setLocateTarget((prev) => ({
+      photoId,
+      token: (prev?.token ?? 0) + 1,
+    }));
+  }, []);
 
   // Share deep link: open the linked photo once on mount (single mode — "look at
   // THIS view"). SSR aligned the initial sub-map to the photo's, so it is already
@@ -265,6 +281,7 @@ export default function VenueMain({
           loading={activePhotosLoading}
           error={photosMatchActive && photosError && !photosLoading}
           selectedPhotoId={selectedPhotoId}
+          locateTarget={locateTarget}
           onOpenLightbox={handleOpenLightbox}
           onRetry={handleRetryPoints}
         />
@@ -327,6 +344,7 @@ export default function VenueMain({
         venue={venue}
         request={lightboxRequest}
         onClose={handleCloseLightbox}
+        onLocate={handleLocatePhoto}
       />
 
       {/* Upload Sheet (step 6). Mounted only while open so the compression lib

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -167,6 +167,19 @@
   }
 }
 
+/* Seatmap locate pulse: the ring is centered with translate because pin markers
+   already use inline transforms on their outer positioning wrapper. */
+@keyframes seatview-locate-pulse {
+  from {
+    opacity: 0.5;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(2.2);
+  }
+}
+
 /* Upload Sheet slide-in (shape-upload-sheet.md §11): desktop/tablet from the
    right, mobile from the bottom. 250ms ease-out-quart. Reduced-motion makes it
    instant via the prefers-reduced-motion rule above. */


### PR DESCRIPTION
## Summary
- Add a Lightbox toolbar action to locate the current photo on the seatmap
- Close the overlay, clear the share URL, keep the target pin selected, then scroll and zoom to the marker
- Add localized locate labels and a reduced-motion-safe seatmap pulse

## Verification
- npm run typecheck
- npm test
- npm run format:check
- npm run build
- Playwright desktop/mobile checks for sequence and single Lightbox locate flows
- Playwright reduced-motion locate check

## Notes
- Local demo image 404s under /r2/demo were observed during browser QA and are unrelated to this change.