### PR TITLE
feat(lightbox): add nearby preview strip

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -192,6 +192,8 @@ const en: Messages = {
     imageError: "This photo can't open right now",
     imageAlt: "View from {label} {date} {event}",
     position: "{n} / {total}",
+    nearbyLabel: "Nearby seat previews",
+    nearbyThumbLabel: "View nearby seat {label}",
     share: "Share this view",
     shareCopied: "Link copied",
     shareText: "I found a great view at {venue}: {url} — come take a look!",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -184,6 +184,8 @@ const ja: Messages = {
     imageError: "この写真は今読み込めません",
     imageAlt: "{label} {date} {event} の視点",
     position: "{n} / {total}",
+    nearbyLabel: "近くの座席プレビュー",
+    nearbyThumbLabel: "近くの視点、{label}を表示",
     share: "この視点をシェア",
     shareCopied: "リンクをコピーしました",
     shareText: "{venue}でいい視点を見つけました：{url} ぜひ見てみてください！",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -190,6 +190,8 @@ const ko: Messages = {
     imageError: "이 사진은 지금 열 수 없어요",
     imageAlt: "{label} {date} {event}의 시점",
     position: "{n} / {total}",
+    nearbyLabel: "가까운 좌석 미리보기",
+    nearbyThumbLabel: "{label}의 가까운 시점 보기",
     share: "이 시야 공유하기",
     shareCopied: "링크가 복사되었습니다",
     shareText: "{venue}에서 멋진 시야를 발견했어요: {url} 보러 오세요!",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -229,6 +229,10 @@ export interface Messages {
     imageAlt: string;
     /** `{n}` / `{total}` → 1-based position and count (sequence mode). */
     position: string;
+    /** Nearby same-cluster strip region aria-label. */
+    nearbyLabel: string;
+    /** `{label}` → user seat label. Nearby thumbnail button aria-label. */
+    nearbyThumbLabel: string;
     /** Share button aria-label / title (footer strip). */
     share: string;
     /** In-place confirmation shown after the share link is copied. */
@@ -741,6 +745,8 @@ const zh: Messages = {
     imageError: "这张照片暂时打不开",
     imageAlt: "{label} {date} {event} 的视角",
     position: "{n} / {total}",
+    nearbyLabel: "附近座位预览",
+    nearbyThumbLabel: "查看附近座位：{label}",
     share: "分享这个视角",
     shareCopied: "链接已复制",
     shareText: "我在{venue}发现了一个不错的视角：{url}，你也来看看吧！",

--- a/src/islands/SeatViewLightbox.tsx
+++ b/src/islands/SeatViewLightbox.tsx
@@ -16,7 +16,9 @@ import {
 import type { Locale } from "@/i18n/config";
 import { useLocale } from "@/hooks/useLocale";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import NearbyStrip from "@/islands/lightbox/NearbyStrip";
 import TurnstileWidget from "@/islands/upload/TurnstileWidget";
+import { clusterPoints, layOutPoints } from "@/lib/cluster";
 import { PHOTO_CORRECTION_LABEL_MAX } from "@/lib/photo-corrections";
 import {
   PhotoCorrectionError,
@@ -32,7 +34,7 @@ import {
   relativeTime,
 } from "@/lib/format";
 import { cn } from "@/lib/utils";
-import type { Venue } from "@/types";
+import type { SubMap, Venue } from "@/types";
 import { subMapLabel, venueName } from "@/i18n";
 import {
   buildShareText,
@@ -78,10 +80,16 @@ interface SeatViewLightboxProps {
   locale: Locale;
   /** Owning venue — used to build share links + the locale-aware share blurb. */
   venue: Venue;
+  /** Full point set for the active sub-map, used for same-cluster previews. */
+  allPhotos: PhotoDto[];
+  /** Active sub-map, providing intrinsic image dimensions for clustering. */
+  subMap: SubMap;
   /** Active request (null = closed). VenueMain owns this state. */
   request: LightboxRequest | null;
   /** Called when the user closes the lightbox (Esc / ✕ / backdrop / swipe). */
   onClose: () => void;
+  /** Navigate to another photo without closing this lightbox. */
+  onNavigate: (photoId: string) => void;
   /** Locate the current photo on the seatmap and close this overlay. */
   onLocate?: (photoId: string) => void;
 }
@@ -119,8 +127,11 @@ function toSlide(dto: PhotoDto, locale: Locale, altTmpl: string): SeatSlide {
 export default function SeatViewLightbox({
   locale,
   venue,
+  allPhotos,
+  subMap,
   request,
   onClose,
+  onNavigate,
   onLocate,
 }: SeatViewLightboxProps) {
   const { t } = useLocale(locale);
@@ -172,6 +183,22 @@ export default function SeatViewLightbox({
   );
 
   const currentPhoto = photos[currentIndex];
+
+  const nearbyPhotos = useMemo(() => {
+    if (!currentPhoto || currentPhoto.subMapId !== subMap.id) return [];
+    const points = layOutPoints(
+      allPhotos.filter((photo) => photo.subMapId === currentPhoto.subMapId),
+      subMap.width,
+      subMap.height,
+    );
+    const currentCluster = clusterPoints(points, 1).find((cluster) =>
+      cluster.members.some((member) => member.photo.id === currentPhoto.id),
+    );
+    if (!currentCluster || currentCluster.members.length <= 1) return [];
+    return currentCluster.members
+      .map((member) => member.photo)
+      .sort((a, b) => b.createdAt - a.createdAt || a.id.localeCompare(b.id));
+  }, [allPhotos, currentPhoto, subMap]);
 
   // `view` fires on every active-slide change (open + each page turn). Re-emit
   // the selected signal so the seatmap pin tracks the visible photo (shape §7).
@@ -395,22 +422,37 @@ export default function SeatViewLightbox({
             />
           );
         },
-        // The detail sheet (rendered above slides, absolute) when expanded.
+        // Bottom same-cluster previews + the detail sheet overlay.
         controls: () =>
-          currentPhoto && detailOpen ? (
-            <DetailSheet
-              dto={currentPhoto}
-              locale={locale}
-              labels={{
-                collapse: t.lightbox.collapse,
-                expand: t.lightbox.expand,
-                uploadedAt: t.lightbox.uploadedAt,
-                correction: t.lightbox.correction,
-              }}
-              correctionOpen={correctionOpen}
-              onCorrectionOpenChange={setCorrectionOpen}
-              onClose={() => setDetailOpen(false)}
-            />
+          currentPhoto ? (
+            <>
+              {nearbyPhotos.length >= 2 && (
+                <NearbyStrip
+                  items={nearbyPhotos}
+                  currentId={currentPhoto.id}
+                  onSelect={onNavigate}
+                  baseUrl={PUBLIC_R2_BASE_URL}
+                  label={t.lightbox.nearbyLabel}
+                  thumbLabelTemplate={t.lightbox.nearbyThumbLabel}
+                  reducedMotion={reducedMotion}
+                />
+              )}
+              {detailOpen && (
+                <DetailSheet
+                  dto={currentPhoto}
+                  locale={locale}
+                  labels={{
+                    collapse: t.lightbox.collapse,
+                    expand: t.lightbox.expand,
+                    uploadedAt: t.lightbox.uploadedAt,
+                    correction: t.lightbox.correction,
+                  }}
+                  correctionOpen={correctionOpen}
+                  onCorrectionOpenChange={setCorrectionOpen}
+                  onClose={() => setDetailOpen(false)}
+                />
+              )}
+            </>
           ) : null,
       }}
     />

--- a/src/islands/VenueMain.tsx
+++ b/src/islands/VenueMain.tsx
@@ -206,6 +206,33 @@ export default function VenueMain({
     });
   }, []);
 
+  const handleNavigatePhoto = useCallback(
+    (photoId: string) => {
+      setLightboxRequest((prev) => {
+        if (!prev) return prev;
+        const target = activePhotos.find((photo) => photo.id === photoId);
+        if (!target) return prev;
+
+        if (prev.mode === "single") {
+          return { mode: "single", photos: [target], index: 0 };
+        }
+
+        const existingIndex = prev.photos.findIndex(
+          (photo) => photo.id === photoId,
+        );
+        if (existingIndex >= 0) return { ...prev, index: existingIndex };
+
+        const fullPhotos = [...activePhotos].sort(
+          (a, b) => b.createdAt - a.createdAt || a.id.localeCompare(b.id),
+        );
+        const fullIndex = fullPhotos.findIndex((photo) => photo.id === photoId);
+        if (fullIndex < 0) return prev;
+        return { mode: "sequence", photos: fullPhotos, index: fullIndex };
+      });
+    },
+    [activePhotos],
+  );
+
   const handleCloseLightbox = useCallback(() => setLightboxRequest(null), []);
 
   const handleLocatePhoto = useCallback((photoId: string) => {
@@ -339,13 +366,18 @@ export default function VenueMain({
         />
       ) : null}
 
-      <SeatViewLightbox
-        locale={locale}
-        venue={venue}
-        request={lightboxRequest}
-        onClose={handleCloseLightbox}
-        onLocate={handleLocatePhoto}
-      />
+      {activeSubMap ? (
+        <SeatViewLightbox
+          locale={locale}
+          venue={venue}
+          allPhotos={activePhotos}
+          subMap={activeSubMap}
+          request={lightboxRequest}
+          onClose={handleCloseLightbox}
+          onNavigate={handleNavigatePhoto}
+          onLocate={handleLocatePhoto}
+        />
+      ) : null}
 
       {/* Upload Sheet (step 6). Mounted only while open so the compression lib
           + Turnstile script aren't loaded until the user contributes. */}

--- a/src/islands/lightbox/NearbyStrip.tsx
+++ b/src/islands/lightbox/NearbyStrip.tsx
@@ -113,7 +113,7 @@ export default function NearbyStrip({
           event.stopPropagation();
         }}
         className={cn(
-          "pointer-events-auto max-w-full overflow-x-auto rounded-full",
+          "pointer-events-auto max-w-full overflow-x-auto rounded-2xl",
           "border border-[oklch(0.8_0.006_86_/_0.22)] bg-[oklch(0.13_0.008_75_/_0.62)]",
           "px-2 py-2 [scrollbar-width:thin] [touch-action:pan-x]",
         )}
@@ -169,7 +169,7 @@ export default function NearbyStrip({
                   loading="lazy"
                   decoding="async"
                   draggable={false}
-                  className="size-full select-none object-contain"
+                  className="size-full select-none object-cover"
                 />
                 {current && (
                   <span

--- a/src/islands/lightbox/NearbyStrip.tsx
+++ b/src/islands/lightbox/NearbyStrip.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef } from "react";
+import type { PhotoDto } from "@/lib/photos";
+import { imageKeyToUrl } from "@/lib/photos";
+import { fillTemplate } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+interface NearbyStripProps {
+  items: PhotoDto[];
+  currentId: string;
+  onSelect: (photoId: string) => void;
+  baseUrl?: string;
+  label: string;
+  thumbLabelTemplate: string;
+  reducedMotion: boolean;
+}
+
+interface DragState {
+  pointerId: number;
+  startX: number;
+  scrollLeft: number;
+  moved: boolean;
+}
+
+export default function NearbyStrip({
+  items,
+  currentId,
+  onSelect,
+  baseUrl,
+  label,
+  thumbLabelTemplate,
+  reducedMotion,
+}: NearbyStripProps) {
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const itemRefs = useRef(new Map<string, HTMLButtonElement>());
+  const dragRef = useRef<DragState | null>(null);
+  const suppressClickRef = useRef(false);
+
+  useEffect(() => {
+    const current = itemRefs.current.get(currentId);
+    current?.scrollIntoView({
+      block: "nearest",
+      inline: "center",
+      behavior: reducedMotion ? "auto" : "smooth",
+    });
+  }, [currentId, reducedMotion]);
+
+  const focusItem = (index: number): void => {
+    const next = items[index];
+    if (!next) return;
+    itemRefs.current.get(next.id)?.focus();
+  };
+
+  return (
+    <div className="pointer-events-none absolute inset-x-0 bottom-[5.25rem] z-[9] flex justify-center px-3 sm:bottom-[5.5rem] sm:px-6">
+      <div
+        ref={scrollerRef}
+        role="region"
+        aria-label={label}
+        onWheel={(event) => {
+          const el = scrollerRef.current;
+          if (!el || el.scrollWidth <= el.clientWidth) return;
+          if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+          el.scrollLeft += event.deltaY;
+          event.preventDefault();
+        }}
+        onPointerDown={(event) => {
+          if (event.pointerType !== "mouse" || event.button !== 0) return;
+          const el = scrollerRef.current;
+          if (!el || el.scrollWidth <= el.clientWidth) return;
+          dragRef.current = {
+            pointerId: event.pointerId,
+            startX: event.clientX,
+            scrollLeft: el.scrollLeft,
+            moved: false,
+          };
+          el.setPointerCapture(event.pointerId);
+        }}
+        onPointerMove={(event) => {
+          const drag = dragRef.current;
+          const el = scrollerRef.current;
+          if (!drag || !el || drag.pointerId !== event.pointerId) return;
+          const deltaX = event.clientX - drag.startX;
+          if (Math.abs(deltaX) > 4) drag.moved = true;
+          if (!drag.moved) return;
+          el.scrollLeft = drag.scrollLeft - deltaX;
+          event.preventDefault();
+        }}
+        onPointerUp={(event) => {
+          const drag = dragRef.current;
+          const el = scrollerRef.current;
+          if (!drag || drag.pointerId !== event.pointerId) return;
+          if (drag.moved) {
+            suppressClickRef.current = true;
+            window.setTimeout(() => {
+              suppressClickRef.current = false;
+            }, 0);
+          }
+          dragRef.current = null;
+          if (el?.hasPointerCapture(event.pointerId)) {
+            el.releasePointerCapture(event.pointerId);
+          }
+        }}
+        onPointerCancel={(event) => {
+          const el = scrollerRef.current;
+          dragRef.current = null;
+          if (el?.hasPointerCapture(event.pointerId)) {
+            el.releasePointerCapture(event.pointerId);
+          }
+        }}
+        onClickCapture={(event) => {
+          if (!suppressClickRef.current) return;
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        className={cn(
+          "pointer-events-auto max-w-full overflow-x-auto rounded-full",
+          "border border-[oklch(0.8_0.006_86_/_0.22)] bg-[oklch(0.13_0.008_75_/_0.62)]",
+          "px-2 py-2 [scrollbar-width:thin] [touch-action:pan-x]",
+        )}
+      >
+        <div className="flex min-w-max items-center gap-2">
+          {items.map((photo, index) => {
+            const current = photo.id === currentId;
+            return (
+              <button
+                key={photo.id}
+                ref={(node) => {
+                  if (node) itemRefs.current.set(photo.id, node);
+                  else itemRefs.current.delete(photo.id);
+                }}
+                type="button"
+                aria-current={current ? "true" : undefined}
+                aria-label={fillTemplate(thumbLabelTemplate, {
+                  label: photo.seatLabel,
+                })}
+                title={photo.seatLabel}
+                onClick={() => {
+                  if (!current) onSelect(photo.id);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "ArrowRight") {
+                    event.preventDefault();
+                    focusItem(Math.min(items.length - 1, index + 1));
+                  } else if (event.key === "ArrowLeft") {
+                    event.preventDefault();
+                    focusItem(Math.max(0, index - 1));
+                  } else if (event.key === "Home") {
+                    event.preventDefault();
+                    focusItem(0);
+                  } else if (event.key === "End") {
+                    event.preventDefault();
+                    focusItem(items.length - 1);
+                  }
+                }}
+                className={cn(
+                  "relative grid h-16 w-20 shrink-0 place-items-center overflow-hidden rounded-md",
+                  "border border-[oklch(0.8_0.006_86_/_0.22)] bg-[oklch(0.16_0.008_75_/_0.78)]",
+                  "transition-[border-color,opacity] duration-150 ease-out",
+                  "hover:border-[oklch(0.8_0.006_86_/_0.46)] hover:opacity-100",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[oklch(0.8_0.006_86)] focus:outline-none",
+                  current
+                    ? "opacity-100 outline outline-2 outline-offset-1 outline-[oklch(0.93_0.006_88_/_0.9)]"
+                    : "opacity-[0.72]",
+                )}
+              >
+                <img
+                  src={imageKeyToUrl(photo.imageKey, baseUrl)}
+                  alt=""
+                  loading="lazy"
+                  decoding="async"
+                  draggable={false}
+                  className="size-full select-none object-contain"
+                />
+                {current && (
+                  <span
+                    className="absolute bottom-1 left-1 h-1.5 w-1.5 rounded-full bg-[oklch(0.93_0.006_88)]"
+                    aria-hidden="true"
+                  />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Adds a bottom nearby-seat preview strip inside the photo lightbox. The strip shows photos from the current photo's scale=1 seatmap cluster and lets users switch photos in place without closing the lightbox.

## Type of change

- [ ] New venue (`data/venues/<venue-id>.json`)
- [ ] Edit to an existing venue
- [x] Site code / docs change
- [ ] Other (describe below)

## Venue checklist (fill in for venue PRs)

- [ ] **Seating chart has no copyright risk.** Charts under `public/seatmaps/`
      are locally-authored placeholders or otherwise free of third-party
      copyright. I did NOT commit a real copyrighted seating chart.
- [ ] **All fields are complete.** `id`, `name_zh`, `name_jp`, `name_romaji`,
      `prefecture`, `city`, `aliases`, and at least one `subMaps[]` entry are
      present and match the `Venue` / `SubMap` types (see CONTRIBUTING.md).
- [ ] **`prefecture` uses a valid slug** from `src/data/prefectures.ts`
      (e.g. `tokyo`, `kanagawa`, `osaka`, `overseas`).
- [ ] **`id` is unique** across `data/venues/*.json` and is a url-safe slug
      (lowercase, hyphenated). The JSON filename equals `<id>.json`.
- [ ] **Each `subMaps[].imageUrl`** points at `public/seatmaps/<id>/<sub-map-id>.svg`
      (or another asset I committed), and `width` / `height` are the chart's
      actual pixel dimensions.
- [x] **The build passes locally**: `npm run build` succeeds and
      `npm run typecheck` reports no errors.

## Notes for the maintainer

Validation:
- `npm run format:check`
- `npm run typecheck` (0 errors, existing `document.execCommand` deprecation hint only)
- `npm test`
- `npm run build` (passes, existing chunk-size warning only)
- `git diff --check origin/main...HEAD`

Browser QA on `http://127.0.0.1:4321/zh/v/yokohama-arena`:
- Single-mode deep link opens with a 2-item nearby strip and no lightbox prev/next arrows.
- Clicking a nearby thumbnail updates the main photo and `?photo=` in place.
- Sequence mode keeps the full 4-photo order; clicking the nearby strip jumps to `4 / 4`, not a 2-photo cluster sequence.
- Isolated clusters hide the strip.
- Mobile 390px viewport keeps the strip above the footer with 80x64 thumbnail buttons.
- Keyboard focus on a nearby thumbnail plus Enter switches photos.

Local demo photo assets return 404 under `/r2/demo/...`; those console errors are from the existing local demo asset setup and are not caused by this change.