### PR TITLE
Add AI search indexing signals

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,29 +1,4 @@
 User-agent: *
 Allow: /
 
-User-agent: Amazonbot
-Disallow: /
-
-User-agent: Applebot-Extended
-Disallow: /
-
-User-agent: Bytespider
-Disallow: /
-
-User-agent: CCBot
-Disallow: /
-
-User-agent: ClaudeBot
-Disallow: /
-
-User-agent: CloudflareBrowserRenderingCrawler
-Disallow: /
-
-User-agent: Google-Extended
-Disallow: /
-
-User-agent: GPTBot
-Disallow: /
-
-User-agent: meta-externalagent
-Disallow: /
+Sitemap: https://seat.genchi.top/sitemap.xml

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -47,6 +47,11 @@ const en: Messages = {
     notFoundTitle: "We haven't collected this venue yet.",
     notFoundBody: "Want to look at other venues from the home page?",
     backHome: "Back to home",
+    seoDescription:
+      "Real seat-view photo atlas for {name} ({location}). Covers audience views from areas such as {subMaps}, with {count} real photos so far.",
+    seoDescriptionEmpty:
+      "Real seat-view photo atlas for {name} ({location}). Covering areas such as {subMaps} — audience photos welcome.",
+    seoSeatListLabel: "Seat views on record",
   },
   seatmap: {
     emptyBody: "No one has shared a view from this area yet.",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -42,6 +42,11 @@ const ja: Messages = {
     notFoundTitle: "この会場はまだ収録されていません。",
     notFoundBody: "トップから他の会場を探してみますか？",
     backHome: "ホームへ",
+    seoDescription:
+      "「{name}」（{location}）の実際の座席からの見え方を集めた写真アトラス。{subMaps}などのエリアの観客投稿を収録し、現在 {count} 枚の実写があります。",
+    seoDescriptionEmpty:
+      "「{name}」（{location}）の実際の座席からの見え方を集めた写真アトラス。{subMaps}などのエリアを対象に、観客の投稿を募集中です。",
+    seoSeatListLabel: "収録済みの座席ビュー",
   },
   seatmap: {
     emptyBody: "このエリアにはまだ視点投稿がありません。",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -46,6 +46,11 @@ const ko: Messages = {
     notFoundTitle: "이 회장은 아직 수록하지 않았어요.",
     notFoundBody: "홈에서 다른 회장을 둘러볼까요?",
     backHome: "홈으로",
+    seoDescription:
+      "{name}({location})의 실제 좌석 시야 사진 도감. {subMaps} 등 구역의 관객 실사 시야를 수록하며 현재 {count}장의 사진이 있습니다.",
+    seoDescriptionEmpty:
+      "{name}({location})의 실제 좌석 시야 사진 도감. {subMaps} 등 구역을 대상으로 관객 사진을 모집 중입니다.",
+    seoSeatListLabel: "수록된 좌석 시야",
   },
   seatmap: {
     emptyBody: "이 구역에는 아직 공유된 시점이 없어요.",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -46,6 +46,14 @@ export interface Messages {
     notFoundTitle: string;
     notFoundBody: string;
     backHome: string;
+    /** SEO `<meta description>` + sr-only summary. Slots: `{name}` `{location}`
+     *  `{subMaps}` `{count}`. Never machine-translate embedded seat labels. */
+    seoDescription: string;
+    /** SEO description variant when the venue has zero photos yet. Slots:
+     *  `{name}` `{location}` `{subMaps}`. */
+    seoDescriptionEmpty: string;
+    /** sr-only heading above the recorded seat-view list (crawler-visible). */
+    seoSeatListLabel: string;
   };
   seatmap: {
     /** Empty sub-map: gentle invitation (shape-seatmap §8). */
@@ -604,6 +612,11 @@ const zh: Messages = {
     notFoundTitle: "这个场馆我们还没收录。",
     notFoundBody: "要不去首页看看其他场馆？",
     backHome: "回到首页",
+    seoDescription:
+      "「{name}」（{location}）的真实座位视野照片图鉴，收录{subMaps}等区域的观众实拍视角，目前共 {count} 张实拍照片。",
+    seoDescriptionEmpty:
+      "「{name}」（{location}）的真实座位视野照片图鉴，涵盖{subMaps}等区域，正在征集观众实拍视角。",
+    seoSeatListLabel: "已收录座位视角",
   },
   seatmap: {
     emptyBody: "这个区域还没有粉丝分享视角。",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,15 +2,18 @@
 import "@/styles/global.css";
 import { getMessages } from "@/i18n";
 import type { Locale } from "@/i18n/config";
+import { localeAlternates } from "@/lib/seo/hreflang";
 
 interface Props {
   title?: string;
+  description?: string;
   locale?: Locale;
 }
 
 const locale: Locale = Astro.props.locale ?? Astro.locals.locale ?? "zh";
 const t = getMessages(locale);
 const title = Astro.props.title ?? t.meta.title;
+const description = Astro.props.description ?? t.meta.tagline;
 const HTML_LANG: Record<Locale, string> = {
   zh: "zh-Hans",
   ja: "ja",
@@ -27,6 +30,9 @@ const OG_LOCALE: Record<Locale, string> = {
 const siteUrl = import.meta.env.PUBLIC_SITE_URL ?? Astro.url.origin;
 const ogImage = new URL("/og.jpg", siteUrl).href;
 const canonical = new URL(Astro.url.pathname, siteUrl).href;
+// hreflang alternates for the four locale-prefixed variants of this route
+// (+ x-default). Skips paths with no locale prefix (e.g. error fallbacks).
+const alternates = localeAlternates(Astro.url.pathname, siteUrl);
 ---
 
 <!doctype html>
@@ -34,8 +40,15 @@ const canonical = new URL(Astro.url.pathname, siteUrl).href;
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content={t.meta.tagline} />
+    <meta name="description" content={description} />
     <title>{title}</title>
+
+    <link rel="canonical" href={canonical} />
+    {
+      alternates.map((alt) => (
+        <link rel="alternate" hreflang={alt.hreflang} href={alt.href} />
+      ))
+    }
 
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
@@ -55,7 +68,7 @@ const canonical = new URL(Astro.url.pathname, siteUrl).href;
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="SeatView" />
     <meta property="og:title" content={title} />
-    <meta property="og:description" content={t.meta.tagline} />
+    <meta property="og:description" content={description} />
     <meta property="og:image" content={ogImage} />
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1200" />
@@ -65,7 +78,7 @@ const canonical = new URL(Astro.url.pathname, siteUrl).href;
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={t.meta.tagline} />
+    <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
     <!-- Page-specific head extras (e.g. the venue page's giscus:backlink). -->
     <slot name="head" />

--- a/src/lib/seo/hreflang-core.ts
+++ b/src/lib/seo/hreflang-core.ts
@@ -1,0 +1,54 @@
+export interface HreflangConfig<Locale extends string> {
+  locales: readonly Locale[];
+  defaultLocale: Locale;
+  hreflang: Record<Locale, string>;
+  isLocale: (value: string | undefined) => value is Locale;
+}
+
+export interface Alternate {
+  hreflang: string;
+  href: string;
+}
+
+/**
+ * Strip the leading `/{locale}` segment from a pathname, returning the
+ * locale-independent remainder (always starting with `/`). A pathname without a
+ * known locale prefix is returned unchanged.
+ */
+export function stripLocale<Locale extends string>(
+  pathname: string,
+  isLocale: HreflangConfig<Locale>["isLocale"],
+): string {
+  const segments = pathname.split("/");
+  if (isLocale(segments[1])) {
+    const rest = segments.slice(2).join("/");
+    return rest ? `/${rest}` : "/";
+  }
+  return pathname;
+}
+
+/** Build the locale-prefixed pathname for `rest` (the stripLocale output). */
+function localePath<Locale extends string>(loc: Locale, rest: string): string {
+  return rest === "/" ? `/${loc}/` : `/${loc}${rest}`;
+}
+
+/**
+ * All hreflang alternates for a given pathname, including the `x-default` entry
+ * that points at the configured default locale.
+ */
+export function localeAlternatesForConfig<Locale extends string>(
+  pathname: string,
+  siteUrl: string | URL,
+  config: HreflangConfig<Locale>,
+): Alternate[] {
+  const rest = stripLocale(pathname, config.isLocale);
+  const alternates: Alternate[] = config.locales.map((loc) => ({
+    hreflang: config.hreflang[loc],
+    href: new URL(localePath(loc, rest), siteUrl).href,
+  }));
+  alternates.push({
+    hreflang: "x-default",
+    href: new URL(localePath(config.defaultLocale, rest), siteUrl).href,
+  });
+  return alternates;
+}

--- a/src/lib/seo/hreflang.test.ts
+++ b/src/lib/seo/hreflang.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  localeAlternatesForConfig,
+  stripLocale,
+  type HreflangConfig,
+} from "./hreflang-core.ts";
+
+const locales = ["zh", "ja", "en", "ko"] as const;
+type TestLocale = (typeof locales)[number];
+
+const config: HreflangConfig<TestLocale> = {
+  locales,
+  defaultLocale: "zh",
+  hreflang: {
+    zh: "zh-Hans",
+    ja: "ja",
+    en: "en",
+    ko: "ko",
+  },
+  isLocale(value: string | undefined): value is TestLocale {
+    return (
+      value !== undefined && (locales as readonly string[]).includes(value)
+    );
+  },
+};
+
+describe("stripLocale", () => {
+  it("strips locale-prefixed root and nested paths", () => {
+    assert.equal(stripLocale("/zh/", config.isLocale), "/");
+    assert.equal(stripLocale("/zh", config.isLocale), "/");
+    assert.equal(
+      stripLocale("/zh/v/k-arena-yokohama", config.isLocale),
+      "/v/k-arena-yokohama",
+    );
+  });
+
+  it("leaves unknown or unprefixed paths unchanged", () => {
+    assert.equal(
+      stripLocale("/fr/v/k-arena-yokohama", config.isLocale),
+      "/fr/v/k-arena-yokohama",
+    );
+    assert.equal(
+      stripLocale("/v/k-arena-yokohama", config.isLocale),
+      "/v/k-arena-yokohama",
+    );
+  });
+});
+
+describe("localeAlternatesForConfig", () => {
+  it("builds all locale alternates plus x-default for the root route", () => {
+    assert.deepEqual(
+      localeAlternatesForConfig("/zh/", "https://seat.genchi.top", config),
+      [
+        { hreflang: "zh-Hans", href: "https://seat.genchi.top/zh/" },
+        { hreflang: "ja", href: "https://seat.genchi.top/ja/" },
+        { hreflang: "en", href: "https://seat.genchi.top/en/" },
+        { hreflang: "ko", href: "https://seat.genchi.top/ko/" },
+        { hreflang: "x-default", href: "https://seat.genchi.top/zh/" },
+      ],
+    );
+  });
+
+  it("rebuilds equivalent locale paths for a venue route", () => {
+    assert.deepEqual(
+      localeAlternatesForConfig(
+        "/ja/v/tokyo-dome",
+        "https://seat.genchi.top",
+        config,
+      ),
+      [
+        {
+          hreflang: "zh-Hans",
+          href: "https://seat.genchi.top/zh/v/tokyo-dome",
+        },
+        { hreflang: "ja", href: "https://seat.genchi.top/ja/v/tokyo-dome" },
+        { hreflang: "en", href: "https://seat.genchi.top/en/v/tokyo-dome" },
+        { hreflang: "ko", href: "https://seat.genchi.top/ko/v/tokyo-dome" },
+        {
+          hreflang: "x-default",
+          href: "https://seat.genchi.top/zh/v/tokyo-dome",
+        },
+      ],
+    );
+  });
+});

--- a/src/lib/seo/hreflang.ts
+++ b/src/lib/seo/hreflang.ts
@@ -1,0 +1,48 @@
+// hreflang alternates for the locale-prefixed routing (R2.4).
+//
+// Every route is locale-prefixed (`/zh/...`, `/ja/...`, ...). Given any one
+// locale's pathname we derive the equivalent URL in every other locale so the
+// <head> can advertise the full set of language alternates (plus x-default,
+// which points at the default locale per Google's guidance). Pure + dependency
+// -free so it unit-tests without a request.
+
+import { locales, defaultLocale, isLocale, type Locale } from "@/i18n/config";
+import {
+  localeAlternatesForConfig,
+  stripLocale as stripLocaleForConfig,
+  type Alternate,
+} from "@/lib/seo/hreflang-core";
+
+/** BCP-47 hreflang value per locale. Simplified Chinese is `zh-Hans`. */
+export const HREFLANG: Record<Locale, string> = {
+  zh: "zh-Hans",
+  ja: "ja",
+  en: "en",
+  ko: "ko",
+};
+
+/**
+ * Strip the leading `/{locale}` segment from a pathname, returning the
+ * locale-independent remainder (always starting with `/`). A pathname without a
+ * known locale prefix is returned unchanged.
+ *   "/zh/v/k-arena" → "/v/k-arena"   "/ja/" → "/"   "/zh" → "/"
+ */
+export function stripLocale(pathname: string): string {
+  return stripLocaleForConfig(pathname, isLocale);
+}
+
+/**
+ * All hreflang alternates for a given (locale-prefixed) pathname, including the
+ * `x-default` entry that points at the default locale.
+ */
+export function localeAlternates(
+  pathname: string,
+  siteUrl: string | URL,
+): Alternate[] {
+  return localeAlternatesForConfig(pathname, siteUrl, {
+    locales,
+    defaultLocale,
+    hreflang: HREFLANG,
+    isLocale,
+  });
+}

--- a/src/lib/seo/jsonld-core.ts
+++ b/src/lib/seo/jsonld-core.ts
@@ -1,0 +1,109 @@
+type JsonLd = Record<string, unknown>;
+
+function abs(path: string, siteUrl: string | URL): string {
+  return new URL(path, siteUrl).href;
+}
+
+export interface MusicVenueLdInput {
+  id: string;
+  name: string;
+  aliases: readonly string[];
+  city: string;
+  imagePath?: string | undefined;
+  prefectureName?: string | undefined;
+  locale: string;
+  siteUrl: string | URL;
+}
+
+export function buildMusicVenueLd(input: MusicVenueLdInput): JsonLd {
+  const address: JsonLd = {
+    "@type": "PostalAddress",
+    addressCountry: "JP",
+  };
+  if (input.prefectureName) address.addressRegion = input.prefectureName;
+  if (input.city) address.addressLocality = input.city;
+
+  const ld: JsonLd = {
+    "@context": "https://schema.org",
+    "@type": "MusicVenue",
+    name: input.name,
+    url: abs(`/${input.locale}/v/${input.id}`, input.siteUrl),
+    address,
+  };
+  if (input.imagePath) ld.image = abs(input.imagePath, input.siteUrl);
+  if (input.aliases.length > 0) ld.alternateName = [...input.aliases];
+  return ld;
+}
+
+export interface BreadcrumbLdInput {
+  locale: string;
+  siteUrl: string | URL;
+  homeName: string;
+  venueId: string;
+  venueName: string;
+  prefectureName?: string | undefined;
+}
+
+/** `BreadcrumbList`: Home → Prefecture (when known) → Venue. */
+export function buildBreadcrumbLd(input: BreadcrumbLdInput): JsonLd {
+  const itemListElement: JsonLd[] = [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: input.homeName,
+      item: abs(`/${input.locale}/`, input.siteUrl),
+    },
+  ];
+
+  if (input.prefectureName) {
+    itemListElement.push({
+      "@type": "ListItem",
+      position: 2,
+      name: input.prefectureName,
+    });
+  }
+
+  itemListElement.push({
+    "@type": "ListItem",
+    position: itemListElement.length + 1,
+    name: input.venueName,
+    item: abs(`/${input.locale}/v/${input.venueId}`, input.siteUrl),
+  });
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement,
+  };
+}
+
+/** `WebSite` for the home page. No SearchAction (search is client-side only). */
+export function buildWebsiteLd(
+  siteUrl: string | URL,
+  locale: string,
+  name: string,
+  description: string,
+): JsonLd {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name,
+    url: abs(`/${locale}/`, siteUrl),
+    description,
+    inLanguage: locale,
+  };
+}
+
+/** `Organization` for the home page. */
+export function buildOrganizationLd(
+  siteUrl: string | URL,
+  name: string,
+): JsonLd {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name,
+    url: abs("/", siteUrl),
+    logo: abs("/logo-mark.png", siteUrl),
+  };
+}

--- a/src/lib/seo/jsonld.test.ts
+++ b/src/lib/seo/jsonld.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildBreadcrumbLd,
+  buildMusicVenueLd,
+  buildOrganizationLd,
+  buildWebsiteLd,
+} from "./jsonld-core.ts";
+
+describe("buildMusicVenueLd", () => {
+  it("builds the required MusicVenue fields and address structure", () => {
+    assert.deepEqual(
+      buildMusicVenueLd({
+        id: "ariake-arena",
+        name: "有明竞技馆",
+        aliases: ["Ariake Arena"],
+        city: "江東区",
+        imagePath: "/seatmaps/ariake-arena/default.webp",
+        prefectureName: "东京都",
+        locale: "zh",
+        siteUrl: "https://seat.genchi.top",
+      }),
+      {
+        "@context": "https://schema.org",
+        "@type": "MusicVenue",
+        name: "有明竞技馆",
+        url: "https://seat.genchi.top/zh/v/ariake-arena",
+        address: {
+          "@type": "PostalAddress",
+          addressCountry: "JP",
+          addressRegion: "东京都",
+          addressLocality: "江東区",
+        },
+        image: "https://seat.genchi.top/seatmaps/ariake-arena/default.webp",
+        alternateName: ["Ariake Arena"],
+      },
+    );
+  });
+});
+
+describe("buildBreadcrumbLd", () => {
+  it("builds Home -> Prefecture -> Venue breadcrumbs when prefecture is known", () => {
+    assert.deepEqual(
+      buildBreadcrumbLd({
+        locale: "zh",
+        siteUrl: "https://seat.genchi.top",
+        homeName: "首页",
+        prefectureName: "东京都",
+        venueName: "有明竞技馆",
+        venueId: "ariake-arena",
+      }),
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          {
+            "@type": "ListItem",
+            position: 1,
+            name: "首页",
+            item: "https://seat.genchi.top/zh/",
+          },
+          {
+            "@type": "ListItem",
+            position: 2,
+            name: "东京都",
+          },
+          {
+            "@type": "ListItem",
+            position: 3,
+            name: "有明竞技馆",
+            item: "https://seat.genchi.top/zh/v/ariake-arena",
+          },
+        ],
+      },
+    );
+  });
+});
+
+describe("home page JSON-LD builders", () => {
+  it("builds WebSite and Organization entities", () => {
+    assert.equal(
+      buildWebsiteLd(
+        "https://seat.genchi.top",
+        "zh",
+        "SeatView",
+        "Real seat views",
+      )["@type"],
+      "WebSite",
+    );
+    assert.deepEqual(
+      buildOrganizationLd("https://seat.genchi.top", "SeatView"),
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        name: "SeatView",
+        url: "https://seat.genchi.top/",
+        logo: "https://seat.genchi.top/logo-mark.png",
+      },
+    );
+  });
+});

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -1,0 +1,76 @@
+// JSON-LD builders for AI/search structured data (R2.2/R2.3).
+//
+// Pure functions: (domain data) → a plain JSON-LD object. The Astro pages
+// serialize the result into a <script type="application/ld+json"> in <head>.
+// No request/DOM access so they unit-test directly. Venue names are resolved
+// per locale; user-authored content is never embedded here.
+
+import type { Venue } from "@/types/venue";
+import type { Prefecture } from "@/data/prefectures";
+import { prefectureName } from "@/data/prefectures";
+import { venueName } from "@/i18n";
+import type { Locale } from "@/i18n/config";
+import {
+  buildBreadcrumbLd,
+  buildMusicVenueLd,
+  buildOrganizationLd,
+  buildWebsiteLd,
+} from "@/lib/seo/jsonld-core";
+
+type JsonLd = Record<string, unknown>;
+
+/**
+ * `MusicVenue` for a venue page. Address is resolved as far as the data goes:
+ * country (always JP), region (prefecture), locality (city). The first sub-map
+ * image stands in as a representative image.
+ */
+export function musicVenueLd(
+  venue: Venue,
+  prefecture: Prefecture | undefined,
+  locale: Locale,
+  siteUrl: string | URL,
+): JsonLd {
+  return buildMusicVenueLd({
+    id: venue.id,
+    name: venueName(venue, locale),
+    aliases: venue.aliases,
+    city: venue.city,
+    imagePath: venue.subMaps[0]?.imageUrl,
+    prefectureName: prefecture ? prefectureName(prefecture, locale) : undefined,
+    locale,
+    siteUrl,
+  });
+}
+
+/** `BreadcrumbList`: Home → Prefecture (when known) → Venue. */
+export function breadcrumbLd(
+  venue: Venue,
+  prefecture: Prefecture | undefined,
+  locale: Locale,
+  siteUrl: string | URL,
+  homeName: string,
+): JsonLd {
+  return buildBreadcrumbLd({
+    locale,
+    siteUrl,
+    homeName,
+    venueId: venue.id,
+    venueName: venueName(venue, locale),
+    prefectureName: prefecture ? prefectureName(prefecture, locale) : undefined,
+  });
+}
+
+/** `WebSite` for the home page. No SearchAction (search is client-side only). */
+export function websiteLd(
+  siteUrl: string | URL,
+  locale: Locale,
+  name: string,
+  description: string,
+): JsonLd {
+  return buildWebsiteLd(siteUrl, locale, name, description);
+}
+
+/** `Organization` for the home page. */
+export function organizationLd(siteUrl: string | URL, name: string): JsonLd {
+  return buildOrganizationLd(siteUrl, name);
+}

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -24,6 +24,7 @@ import SectionHeading from "@/components/SectionHeading.astro";
 import { asLocale } from "@/i18n/config";
 import { getMessages, venueName } from "@/i18n";
 import { getVenue } from "@/data/venues";
+import { websiteLd, organizationLd } from "@/lib/seo/jsonld";
 
 const locale = asLocale(Astro.params.lang);
 const t = getMessages(locale);
@@ -54,9 +55,26 @@ const steps = [
 
 // Split the upload-rule-3 line around the {license} slot for the inline link.
 const rule3Parts = t.home.rule3.split("{license}");
+
+// Structured data (R2.3): WebSite + Organization, injected into <head>.
+const siteUrl = import.meta.env.PUBLIC_SITE_URL ?? Astro.url.origin;
+const jsonLd = [
+  websiteLd(siteUrl, locale, "SeatView", t.meta.tagline),
+  organizationLd(siteUrl, "SeatView"),
+];
 ---
 
 <Layout locale={locale}>
+  {
+    jsonLd.map((ld) => (
+      <script
+        is:inline
+        slot="head"
+        type="application/ld+json"
+        set:html={JSON.stringify(ld)}
+      />
+    ))
+  }
   <div class="flex min-h-screen flex-col">
     <SiteHeader locale={locale} />
 

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -16,9 +16,11 @@ import VenueMain from "@/islands/VenueMain.tsx";
 import VenueComments from "@/islands/VenueComments.tsx";
 import VenuePhotoCountLine from "@/islands/VenuePhotoCountLine.tsx";
 import { asLocale } from "@/i18n/config";
-import { getMessages, venueName } from "@/i18n";
+import { getMessages, venueName, subMapLabel } from "@/i18n";
 import { getVenue } from "@/data/venues";
 import { getPrefecture, prefectureName } from "@/data/prefectures";
+import { fillTemplate, performanceDate } from "@/lib/format";
+import { musicVenueLd, breadcrumbLd } from "@/lib/seo/jsonld";
 import { readSubMapFromUrl, resolveInitialSubMapId } from "@/lib/submap";
 import { readPhotoIdFromUrl } from "@/lib/share";
 import { STORAGE_KEYS } from "@/lib/storage";
@@ -108,6 +110,37 @@ if (venue && env.DB) {
 const prefecture = venue ? getPrefecture(venue.prefecture) : undefined;
 const title = venue ? `${venueName(venue, locale)} · SeatView` : "SeatView";
 
+// SEO (R1.1/R1.3): a per-venue <meta description> + a crawler-visible sr-only
+// summary, both built from data the page already rendered server-side (the
+// `initialPhotoCounts` aggregate + the initial sub-map's `initialPhotos`). No
+// extra D1 query, no visible UI change. User-authored seat labels / event names
+// are surfaced verbatim (R9.5 — never machine-translated).
+let seoDescription = t.meta.tagline;
+let seoSummaryName = "";
+if (venue) {
+  const localeName = venueName(venue, locale);
+  const location = [
+    prefecture ? prefectureName(prefecture, locale) : "",
+    venue.city,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const subMapList = venue.subMaps
+    .map((s) => subMapLabel(s, locale))
+    .join("、");
+  const totalPhotos = initialPhotoCounts?.total ?? 0;
+  seoSummaryName = localeName;
+  seoDescription = fillTemplate(
+    totalPhotos > 0 ? t.venue.seoDescription : t.venue.seoDescriptionEmpty,
+    {
+      name: localeName,
+      location,
+      subMaps: subMapList,
+      count: String(totalPhotos),
+    },
+  );
+}
+
 // SSR-read the venue rating aggregate (ONE `venue_rating_agg` row — never an
 // AVG over rating rows) + this viewer's own score (by salted ip_hash, same
 // privacy model as staging votedByMe). Fails soft to a zero summary so a D1
@@ -143,14 +176,30 @@ const siteUrl = import.meta.env.PUBLIC_SITE_URL ?? Astro.url.origin;
 const giscusBacklink = venue
   ? new URL(`/${locale}/v/${venue.id}`, siteUrl).href
   : undefined;
+
+// Structured data (R2.2): MusicVenue + BreadcrumbList, injected into <head>.
+const jsonLd = venue
+  ? [
+      musicVenueLd(venue, prefecture, locale, siteUrl),
+      breadcrumbLd(venue, prefecture, locale, siteUrl, t.nav.home),
+    ]
+  : [];
 ---
 
-<Layout locale={locale} title={title}>
+<Layout locale={locale} title={title} description={seoDescription}>
   {
     venue && giscusBacklink ? (
       <meta slot="head" name="giscus:backlink" content={giscusBacklink} />
     ) : null
   }
+  {jsonLd.map((ld) => (
+    <script
+      is:inline
+      slot="head"
+      type="application/ld+json"
+      set:html={JSON.stringify(ld)}
+    />
+  ))}
   {
     venue ? (
       <Fragment>
@@ -323,6 +372,32 @@ const giscusBacklink = venue
 
           {/* Main column: breadcrumb → title → tabs → seatmap → upload → grid. */}
           <main class="min-w-0 flex-1">
+            {/* SEO summary (R1.3): visually hidden but present in the DOM /
+                accessibility tree, so crawlers and AT read the venue description
+                + real seat labels even before the React islands hydrate. Pure
+                text — no layout impact. */}
+            <section class="sr-only">
+              <h2>{seoSummaryName}</h2>
+              <p>{seoDescription}</p>
+              {initialPhotos.length > 0 && (
+                <Fragment>
+                  <h3>{t.venue.seoSeatListLabel}</h3>
+                  <ul>
+                    {initialPhotos.map((p) => {
+                      const date = performanceDate(p.performanceDate, locale);
+                      const extra = [p.eventName, date]
+                        .filter(Boolean)
+                        .join(" · ");
+                      return (
+                        <li>
+                          {extra ? `${p.seatLabel} — ${extra}` : p.seatLabel}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </Fragment>
+              )}
+            </section>
             <div class="mx-auto max-w-[900px] px-4 py-6 lg:px-8 lg:py-8">
               {/* Mobile-only search (header search is desktop-only). */}
               <div class="mb-4 lg:hidden">

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,49 @@
+// GET /llms.txt — context file for AI systems (llmstxt.org), R3.1.
+//
+// A plain-text overview an LLM can read without rendering: what SeatView is, the
+// key entry pages, and the full venue list with canonical (zh) URLs. Generated
+// from the static `venues` array so it stays current as venues are added.
+import type { APIRoute } from "astro";
+import { venues } from "@/data/venues";
+
+export const prerender = false;
+
+export const GET: APIRoute = ({ request }) => {
+  const siteUrl =
+    import.meta.env.PUBLIC_SITE_URL ?? new URL(request.url).origin;
+  const url = (path: string) => new URL(path, siteUrl).href;
+
+  const venueLines = venues
+    .map((v) => `- ${v.name_zh} / ${v.name_romaji}: ${url(`/zh/v/${v.id}`)}`)
+    .join("\n");
+
+  const body = `# SeatView
+
+> 日本の演唱会・ライブ会場の「実際の座席からの見え方」を集めた写真アトラス。
+> A community-maintained photo atlas of real seat-view photos for Japanese
+> concert and live venues. Each venue page maps audience-uploaded photos onto
+> the seating chart, so you can see what a given seat actually sees before you
+> buy or attend. Content is contributor-uploaded under CC BY-NC 4.0.
+
+Languages: Simplified Chinese (zh, default), Japanese (ja), English (en), Korean (ko).
+Every route is locale-prefixed, e.g. ${url("/zh/v/k-arena-yokohama")}.
+
+## Key pages
+- Home / intro: ${url("/zh/")}
+- Suggest a venue (staging): ${url("/zh/staging")}
+- Friend links: ${url("/zh/links")}
+- Privacy: ${url("/zh/privacy")}
+- Terms: ${url("/zh/terms")}
+- Sitemap: ${url("/sitemap.xml")}
+
+## Venues (${venues.length})
+${venueLines}
+`;
+
+  return new Response(body, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "public, max-age=3600",
+    },
+  });
+};

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,69 @@
+// GET /sitemap.xml — locale-aware sitemap with hreflang alternates (R2.1).
+//
+// One <url> per (path × locale). Each entry advertises every locale variant via
+// <xhtml:link rel="alternate"> (+ x-default → the default locale), matching the
+// hreflang links emitted in <head>. Driven by the static `venues` array, so it
+// stays in sync as venues are added by PR — zero D1 access.
+import type { APIRoute } from "astro";
+import { venues } from "@/data/venues";
+import { locales, defaultLocale, type Locale } from "@/i18n/config";
+import { HREFLANG } from "@/lib/seo/hreflang";
+
+export const prerender = false;
+
+// Public, indexable routes only (no admin / staging / api). Each is the
+// locale-independent remainder; "/" is the home page.
+const STATIC_PATHS = ["/", "/links", "/privacy", "/terms"] as const;
+
+function localePath(loc: Locale, rest: string): string {
+  return rest === "/" ? `/${loc}/` : `/${loc}${rest}`;
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export const GET: APIRoute = ({ request }) => {
+  const siteUrl =
+    import.meta.env.PUBLIC_SITE_URL ?? new URL(request.url).origin;
+
+  const restPaths = [...STATIC_PATHS, ...venues.map((v) => `/v/${v.id}`)];
+
+  const urls: string[] = [];
+  for (const rest of restPaths) {
+    // Pre-compute the alternate set once per path (same for every locale entry).
+    const links = [
+      ...locales.map(
+        (loc) =>
+          `<xhtml:link rel="alternate" hreflang="${HREFLANG[loc]}" href="${xmlEscape(
+            new URL(localePath(loc, rest), siteUrl).href,
+          )}"/>`,
+      ),
+      `<xhtml:link rel="alternate" hreflang="x-default" href="${xmlEscape(
+        new URL(localePath(defaultLocale, rest), siteUrl).href,
+      )}"/>`,
+    ].join("");
+
+    for (const loc of locales) {
+      const lofrom = xmlEscape(new URL(localePath(loc, rest), siteUrl).href);
+      urls.push(`<url><loc>${lofrom}</loc>${links}</url>`);
+    }
+  }
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+${urls.join("\n")}
+</urlset>
+`;
+
+  return new Response(body, {
+    headers: {
+      "content-type": "application/xml; charset=utf-8",
+      "cache-control": "public, max-age=3600",
+    },
+  });
+};


### PR DESCRIPTION
## What does this PR do?

Adds AI-search indexing signals for SeatView: AI crawler access, locale-aware sitemap + hreflang, per-venue meta descriptions and crawler-readable summaries, JSON-LD structured data, and `/llms.txt`.

## Type of change

- [ ] New venue (`data/venues/<venue-id>.json`)
- [ ] Edit to an existing venue
- [x] Site code / docs change
- [ ] Other (describe below)

## Venue checklist (fill in for venue PRs)

- [ ] **Seating chart has no copyright risk.** Charts under `public/seatmaps/`
      are locally-authored placeholders or otherwise free of third-party
      copyright. I did NOT commit a real copyrighted seating chart.
- [ ] **All fields are complete.** `id`, `name_zh`, `name_jp`, `name_romaji`,
      `prefecture`, `city`, `aliases`, and at least one `subMaps[]` entry are
      present and match the `Venue` / `SubMap` types (see CONTRIBUTING.md).
- [ ] **`prefecture` uses a valid slug** from `src/data/prefectures.ts`
      (e.g. `tokyo`, `kanagawa`, `osaka`, `overseas`).
- [ ] **`id` is unique** across `data/venues/*.json` and is a url-safe slug
      (lowercase, hyphenated). The JSON filename equals `<id>.json`.
- [ ] **Each `subMaps[].imageUrl`** points at `public/seatmaps/<id>/<sub-map-id>.svg`
      (or another asset I committed), and `width` / `height` are the chart's
      actual pixel dimensions.
- [x] **The build passes locally**: `npm run build` succeeds and
      `npm run typecheck` reports no errors.

## Notes for the maintainer

Validation run locally:

- `npm test` (27 tests)
- `npm run typecheck` (0 errors; existing `document.execCommand` deprecation hint only)
- `npm run format:check`
- `npm run build` (existing chunk-size warning only)

Additional local worker smoke check:

- `/zh/v/ariake-arena` emits `MusicVenue` + `BreadcrumbList` JSON-LD.
- BreadcrumbList is `首页 -> 东京都 -> 有明竞技馆`.
- `/sitemap.xml` and `/llms.txt` are generated from venue data.