### PR TITLE
feat(seo): sitemap lastmod, MusicVenue aggregateRating, venue photo ImageGallery

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -38,5 +38,15 @@ export default defineConfig({
   },
   vite: {
     plugins: [tailwindcss()],
+    define: {
+      // Build-time timestamp, inlined once when this config is evaluated (the
+      // `astro build` moment on the build machine). Used as the sitemap
+      // `<lastmod>` — stable across requests within a deploy. The SSR sitemap
+      // route runs per-request, so a `new Date()` there would be request time
+      // and make lastmod churn on every hit; this changes only on redeploy. The
+      // sitemap is kept intentionally D1-free, so per-venue freshness isn't
+      // available — this is a site-wide "last deployed" signal.
+      __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+    },
   },
 });

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -73,3 +73,7 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// Build-time constant injected via Vite `define` in astro.config.mjs. ISO 8601
+// timestamp of the `astro build` moment; used as the sitemap `<lastmod>`.
+declare const __BUILD_TIME__: string;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,6 +8,10 @@ interface Props {
   title?: string;
   description?: string;
   locale?: Locale;
+  // When true, emit `<meta name="robots" content="noindex,follow">` so crawlers
+  // skip indexing this page but still follow its links. Used by low-value UGC /
+  // gated pages (staging, admin) that should not surface in search results.
+  noindex?: boolean;
 }
 
 const locale: Locale = Astro.props.locale ?? Astro.locals.locale ?? "zh";
@@ -33,6 +37,7 @@ const canonical = new URL(Astro.url.pathname, siteUrl).href;
 // hreflang alternates for the four locale-prefixed variants of this route
 // (+ x-default). Skips paths with no locale prefix (e.g. error fallbacks).
 const alternates = localeAlternates(Astro.url.pathname, siteUrl);
+const noindex = Astro.props.noindex ?? false;
 ---
 
 <!doctype html>
@@ -43,11 +48,16 @@ const alternates = localeAlternates(Astro.url.pathname, siteUrl);
     <meta name="description" content={description} />
     <title>{title}</title>
 
+    {noindex && <meta name="robots" content="noindex,follow" />}
+
     <link rel="canonical" href={canonical} />
     {
-      alternates.map((alt) => (
-        <link rel="alternate" hreflang={alt.hreflang} href={alt.href} />
-      ))
+      /* hreflang advertises an indexable locale cluster — skip it on noindex
+         pages so we don't invite indexing of a page we've asked to exclude. */
+      !noindex &&
+        alternates.map((alt) => (
+          <link rel="alternate" hreflang={alt.hreflang} href={alt.href} />
+        ))
     }
 
     <link rel="icon" href="/favicon.ico" sizes="any" />

--- a/src/lib/seo/jsonld-core.ts
+++ b/src/lib/seo/jsonld-core.ts
@@ -96,6 +96,50 @@ export function buildBreadcrumbLd(input: BreadcrumbLdInput): JsonLd {
   };
 }
 
+export interface VenueImageLd {
+  contentUrl: string;
+  /** User-authored seat label (+ event/date); surfaced verbatim, not translated. */
+  caption: string;
+  width?: number | undefined;
+  height?: number | undefined;
+}
+
+export interface VenuePhotosLdInput {
+  name: string;
+  pageUrl: string;
+  images: readonly VenueImageLd[];
+  /** License URL applied to every photo (all uploads share one CC license). */
+  license?: string | undefined;
+}
+
+/**
+ * `ImageGallery` of the seat-view photos rendered on a venue page. The photo
+ * grid hydrates client-side, so these `ImageObject` entries give crawlers an
+ * explicit, render-free signal of each image's URL, caption and license —
+ * the Google Images / image-license path a JS-rendered `<img>` serves weakly.
+ * Returns `null` when there are no photos (caller omits the script entirely).
+ */
+export function buildVenuePhotosLd(input: VenuePhotosLdInput): JsonLd | null {
+  if (input.images.length === 0) return null;
+  return {
+    "@context": "https://schema.org",
+    "@type": "ImageGallery",
+    name: input.name,
+    url: input.pageUrl,
+    image: input.images.map((img) => {
+      const obj: JsonLd = {
+        "@type": "ImageObject",
+        contentUrl: img.contentUrl,
+        caption: img.caption,
+      };
+      if (img.width) obj.width = img.width;
+      if (img.height) obj.height = img.height;
+      if (input.license) obj.license = input.license;
+      return obj;
+    }),
+  };
+}
+
 /** `WebSite` for the home page. No SearchAction (search is client-side only). */
 export function buildWebsiteLd(
   siteUrl: string | URL,

--- a/src/lib/seo/jsonld-core.ts
+++ b/src/lib/seo/jsonld-core.ts
@@ -4,6 +4,13 @@ function abs(path: string, siteUrl: string | URL): string {
   return new URL(path, siteUrl).href;
 }
 
+export interface AggregateRatingLd {
+  ratingValue: number;
+  ratingCount: number;
+  bestRating: number;
+  worstRating: number;
+}
+
 export interface MusicVenueLdInput {
   id: string;
   name: string;
@@ -13,6 +20,9 @@ export interface MusicVenueLdInput {
   prefectureName?: string | undefined;
   locale: string;
   siteUrl: string | URL;
+  // Omitted when the venue has too few ratings to expose (SEO B); only attached
+  // when present, so low-sample venues carry no aggregateRating at all.
+  aggregateRating?: AggregateRatingLd | undefined;
 }
 
 export function buildMusicVenueLd(input: MusicVenueLdInput): JsonLd {
@@ -32,6 +42,15 @@ export function buildMusicVenueLd(input: MusicVenueLdInput): JsonLd {
   };
   if (input.imagePath) ld.image = abs(input.imagePath, input.siteUrl);
   if (input.aliases.length > 0) ld.alternateName = [...input.aliases];
+  if (input.aggregateRating) {
+    ld.aggregateRating = {
+      "@type": "AggregateRating",
+      ratingValue: input.aggregateRating.ratingValue,
+      ratingCount: input.aggregateRating.ratingCount,
+      bestRating: input.aggregateRating.bestRating,
+      worstRating: input.aggregateRating.worstRating,
+    };
+  }
   return ld;
 }
 

--- a/src/lib/seo/jsonld.test.ts
+++ b/src/lib/seo/jsonld.test.ts
@@ -4,6 +4,7 @@ import {
   buildBreadcrumbLd,
   buildMusicVenueLd,
   buildOrganizationLd,
+  buildVenuePhotosLd,
   buildWebsiteLd,
 } from "./jsonld-core.ts";
 
@@ -108,6 +109,46 @@ describe("buildBreadcrumbLd", () => {
         ],
       },
     );
+  });
+});
+
+describe("buildVenuePhotosLd", () => {
+  it("returns null when there are no photos", () => {
+    assert.equal(
+      buildVenuePhotosLd({
+        name: "有明竞技馆",
+        pageUrl: "https://seat.genchi.top/zh/v/ariake-arena",
+        images: [],
+      }),
+      null,
+    );
+  });
+
+  it("builds an ImageGallery of ImageObjects with caption + license", () => {
+    const ld = buildVenuePhotosLd({
+      name: "有明竞技馆",
+      pageUrl: "https://seat.genchi.top/zh/v/ariake-arena",
+      license: "https://creativecommons.org/licenses/by-nc/4.0/",
+      images: [
+        {
+          contentUrl: "https://img.genchi.top/abc.webp",
+          caption: "2階 A列 — ライブ · 2026-05-01",
+          width: 1600,
+          height: 1200,
+        },
+      ],
+    });
+    assert.equal(ld?.["@type"], "ImageGallery");
+    assert.deepEqual(ld?.image, [
+      {
+        "@type": "ImageObject",
+        contentUrl: "https://img.genchi.top/abc.webp",
+        caption: "2階 A列 — ライブ · 2026-05-01",
+        width: 1600,
+        height: 1200,
+        license: "https://creativecommons.org/licenses/by-nc/4.0/",
+      },
+    ]);
   });
 });
 

--- a/src/lib/seo/jsonld.test.ts
+++ b/src/lib/seo/jsonld.test.ts
@@ -38,6 +38,41 @@ describe("buildMusicVenueLd", () => {
   });
 });
 
+describe("buildMusicVenueLd aggregateRating", () => {
+  const base = {
+    id: "ariake-arena",
+    name: "有明竞技馆",
+    aliases: [] as string[],
+    city: "江東区",
+    locale: "zh",
+    siteUrl: "https://seat.genchi.top",
+  };
+
+  it("attaches an AggregateRating when one is provided", () => {
+    const ld = buildMusicVenueLd({
+      ...base,
+      aggregateRating: {
+        ratingValue: 4.3,
+        ratingCount: 12,
+        bestRating: 5,
+        worstRating: 1,
+      },
+    });
+    assert.deepEqual(ld.aggregateRating, {
+      "@type": "AggregateRating",
+      ratingValue: 4.3,
+      ratingCount: 12,
+      bestRating: 5,
+      worstRating: 1,
+    });
+  });
+
+  it("omits aggregateRating entirely when not provided", () => {
+    const ld = buildMusicVenueLd(base);
+    assert.equal("aggregateRating" in ld, false);
+  });
+});
+
 describe("buildBreadcrumbLd", () => {
   it("builds Home -> Prefecture -> Venue breadcrumbs when prefecture is known", () => {
     assert.deepEqual(

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -18,10 +18,19 @@ import {
   buildBreadcrumbLd,
   buildMusicVenueLd,
   buildOrganizationLd,
+  buildVenuePhotosLd,
   buildWebsiteLd,
+  type VenueImageLd,
 } from "@/lib/seo/jsonld-core";
 
 type JsonLd = Record<string, unknown>;
+
+/** CC BY-NC 4.0 — the single license every uploaded photo is contributed under. */
+export const PHOTO_LICENSE_URL =
+  "https://creativecommons.org/licenses/by-nc/4.0/";
+
+/** Cap how many seat-view photos enter the ImageGallery JSON-LD (keep <head> lean). */
+export const VENUE_PHOTOS_LD_MAX = 30;
 
 /**
  * `MusicVenue` for a venue page. Address is resolved as far as the data goes:
@@ -48,6 +57,25 @@ export function musicVenueLd(
     aggregateRating: ratingSummary
       ? (venueAggregateRating(ratingSummary) ?? undefined)
       : undefined,
+  });
+}
+
+/**
+ * `ImageGallery` of a venue's seat-view photos for crawler image discovery.
+ * Caller passes already-resolved (URL + locale-aware caption) images — kept out
+ * of this layer so date/locale formatting stays at the page. Caps at
+ * {@link VENUE_PHOTOS_LD_MAX}. Returns `null` when there are no photos.
+ */
+export function venuePhotosLd(
+  name: string,
+  pageUrl: string,
+  images: readonly VenueImageLd[],
+): JsonLd | null {
+  return buildVenuePhotosLd({
+    name,
+    pageUrl,
+    images: images.slice(0, VENUE_PHOTOS_LD_MAX),
+    license: PHOTO_LICENSE_URL,
   });
 }
 

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -11,6 +11,10 @@ import { prefectureName } from "@/data/prefectures";
 import { venueName } from "@/i18n";
 import type { Locale } from "@/i18n/config";
 import {
+  venueAggregateRating,
+  type VenueRatingSummaryDto,
+} from "@/lib/venue-rating";
+import {
   buildBreadcrumbLd,
   buildMusicVenueLd,
   buildOrganizationLd,
@@ -29,6 +33,7 @@ export function musicVenueLd(
   prefecture: Prefecture | undefined,
   locale: Locale,
   siteUrl: string | URL,
+  ratingSummary?: VenueRatingSummaryDto,
 ): JsonLd {
   return buildMusicVenueLd({
     id: venue.id,
@@ -39,6 +44,10 @@ export function musicVenueLd(
     prefectureName: prefecture ? prefectureName(prefecture, locale) : undefined,
     locale,
     siteUrl,
+    // Only attached when the venue clears the min-sample threshold (SEO B).
+    aggregateRating: ratingSummary
+      ? (venueAggregateRating(ratingSummary) ?? undefined)
+      : undefined,
   });
 }
 

--- a/src/lib/venue-rating.test.ts
+++ b/src/lib/venue-rating.test.ts
@@ -2,11 +2,13 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   applyOptimisticRating,
+  AGGREGATE_RATING_MIN_COUNT,
   emptyRatingSums,
   isValidRatingScore,
   isValidRatingScores,
   ratingDimensionAverage,
   ratingOverallAverage,
+  venueAggregateRating,
   RATING_DIMENSIONS,
   RATING_MAX,
   RATING_MIN,
@@ -98,6 +100,41 @@ describe("rating averages", () => {
       yourScores: null,
     };
     assert.equal(ratingOverallAverage(summary), 4.3);
+  });
+});
+
+describe("venueAggregateRating", () => {
+  // A summary with `count` raters whose dimension sums average to 4.0 overall
+  // (each of the 4 dimensions sums to count*4).
+  const summaryWith = (count: number): VenueRatingSummaryDto => ({
+    count,
+    sums: {
+      view: count * 4,
+      sound: count * 4,
+      amenities: count * 4,
+      transit: count * 4,
+    },
+    yourScores: null,
+  });
+
+  it("returns null when nobody rated", () => {
+    assert.equal(venueAggregateRating(summaryWith(0)), null);
+  });
+
+  it("returns null just below the min-count threshold", () => {
+    assert.equal(
+      venueAggregateRating(summaryWith(AGGREGATE_RATING_MIN_COUNT - 1)),
+      null,
+    );
+  });
+
+  it("projects ratingValue/count/best/worst at the threshold", () => {
+    assert.deepEqual(venueAggregateRating(summaryWith(AGGREGATE_RATING_MIN_COUNT)), {
+      ratingValue: 4,
+      ratingCount: AGGREGATE_RATING_MIN_COUNT,
+      bestRating: RATING_MAX,
+      worstRating: RATING_MIN,
+    });
   });
 });
 

--- a/src/lib/venue-rating.test.ts
+++ b/src/lib/venue-rating.test.ts
@@ -129,12 +129,15 @@ describe("venueAggregateRating", () => {
   });
 
   it("projects ratingValue/count/best/worst at the threshold", () => {
-    assert.deepEqual(venueAggregateRating(summaryWith(AGGREGATE_RATING_MIN_COUNT)), {
-      ratingValue: 4,
-      ratingCount: AGGREGATE_RATING_MIN_COUNT,
-      bestRating: RATING_MAX,
-      worstRating: RATING_MIN,
-    });
+    assert.deepEqual(
+      venueAggregateRating(summaryWith(AGGREGATE_RATING_MIN_COUNT)),
+      {
+        ratingValue: 4,
+        ratingCount: AGGREGATE_RATING_MIN_COUNT,
+        bestRating: RATING_MAX,
+        worstRating: RATING_MIN,
+      },
+    );
   });
 });
 

--- a/src/lib/venue-rating.ts
+++ b/src/lib/venue-rating.ts
@@ -134,6 +134,43 @@ export function ratingOverallAverage(
 }
 
 /**
+ * Minimum number of raters before a venue exposes an `aggregateRating` in its
+ * structured data (SEO B). Below this, the sample is too small to be
+ * representative and a star rich-result could read as noise / manipulation, so
+ * we emit no `aggregateRating` at all (never a fake low-sample value).
+ */
+export const AGGREGATE_RATING_MIN_COUNT = 5;
+
+/** The schema.org AggregateRating projection of a rating summary. */
+export interface VenueAggregateRating {
+  /** Overall average across all dimensions, 1..5, one decimal. */
+  ratingValue: number;
+  /** Number of distinct raters. */
+  ratingCount: number;
+  bestRating: number;
+  worstRating: number;
+}
+
+/**
+ * Project a rating summary to an `aggregateRating` for JSON-LD, or `null` when
+ * the sample is below {@link AGGREGATE_RATING_MIN_COUNT} (or nobody rated).
+ * Equal-weights the four dimensions via {@link ratingOverallAverage}.
+ */
+export function venueAggregateRating(
+  summary: VenueRatingSummaryDto,
+): VenueAggregateRating | null {
+  if (summary.count < AGGREGATE_RATING_MIN_COUNT) return null;
+  const ratingValue = ratingOverallAverage(summary);
+  if (ratingValue === null) return null;
+  return {
+    ratingValue,
+    ratingCount: summary.count,
+    bestRating: RATING_MAX,
+    worstRating: RATING_MIN,
+  };
+}
+
+/**
  * Whether two dimension-score sets are identical. The single equality used by
  * the client's optimistic gate, the server's no-op detection AND the
  * optimistic-apply below, so those three layers cannot drift. `null` (no

--- a/src/pages/[lang]/admin.astro
+++ b/src/pages/[lang]/admin.astro
@@ -42,7 +42,7 @@ for (const v of venues) {
 const r2BaseUrl = import.meta.env.PUBLIC_R2_BASE_URL ?? "";
 ---
 
-<Layout locale={locale} title={`${t.admin.title} · SeatView`}>
+<Layout locale={locale} title={`${t.admin.title} · SeatView`} noindex>
   <div class="flex min-h-screen flex-col">
     <SiteHeader locale={locale} />
     <main class="flex-1">

--- a/src/pages/[lang]/staging.astro
+++ b/src/pages/[lang]/staging.astro
@@ -55,7 +55,7 @@ if (env.DB) {
 }
 ---
 
-<Layout locale={locale} title={`${t.staging.pageTitle} · SeatView`}>
+<Layout locale={locale} title={`${t.staging.pageTitle} · SeatView`} noindex>
   <div class="flex min-h-screen flex-col">
     <SiteHeader locale={locale} />
 

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -180,7 +180,7 @@ const giscusBacklink = venue
 // Structured data (R2.2): MusicVenue + BreadcrumbList, injected into <head>.
 const jsonLd = venue
   ? [
-      musicVenueLd(venue, prefecture, locale, siteUrl),
+      musicVenueLd(venue, prefecture, locale, siteUrl, ratingSummary),
       breadcrumbLd(venue, prefecture, locale, siteUrl, t.nav.home),
     ]
   : [];

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -178,17 +178,25 @@ const giscusBacklink = venue
   ? new URL(`/${locale}/v/${venue.id}`, siteUrl).href
   : undefined;
 
-// Seat-view photos as crawler-readable ImageObject metadata (SEO C2). The photo
-// grid hydrates client-side, so this gives image search an explicit URL +
-// caption + license per initial-sub-map photo without relying on JS rendering.
-// Captions reuse the user-authored seat label + event/date verbatim (R9.5).
+// Seat-view photos as crawler-readable SSR <img> nodes (SEO C1) + ImageObject
+// metadata (SEO C2). The photo grid hydrates client-side, so this gives image
+// search an explicit URL + caption + license per initial-sub-map photo without
+// relying on JS rendering. Captions reuse the user-authored seat label +
+// event/date verbatim (R9.5).
 const r2BaseUrl = import.meta.env.PUBLIC_R2_BASE_URL;
-const photoImages = initialPhotos.map((p) => {
+const initialPhotoSeoImages = initialPhotos.map((p) => {
   const date = performanceDate(p.performanceDate, locale);
   const extra = [p.eventName, date].filter(Boolean).join(" · ");
+  const caption = extra ? `${p.seatLabel} — ${extra}` : p.seatLabel;
+  const contentUrl = new URL(imageKeyToUrl(p.imageKey, r2BaseUrl), siteUrl).href;
   return {
-    contentUrl: imageKeyToUrl(p.imageKey, r2BaseUrl),
-    caption: extra ? `${p.seatLabel} — ${extra}` : p.seatLabel,
+    contentUrl,
+    caption,
+    alt: fillTemplate(t.lightbox.imageAlt, {
+      label: p.seatLabel,
+      date: date ?? "",
+      event: p.eventName ?? "",
+    }),
     width: p.width,
     height: p.height,
   };
@@ -203,7 +211,7 @@ const jsonLd = venue
       venuePhotosLd(
         venueName(venue, locale),
         new URL(`/${locale}/v/${venue.id}`, siteUrl).href,
-        photoImages,
+        initialPhotoSeoImages,
       ),
     ].filter((ld): ld is Record<string, unknown> => ld !== null)
   : [];
@@ -397,26 +405,28 @@ const jsonLd = venue
           <main class="min-w-0 flex-1">
             {/* SEO summary (R1.3): visually hidden but present in the DOM /
                 accessibility tree, so crawlers and AT read the venue description
-                + real seat labels even before the React islands hydrate. Pure
-                text — no layout impact. */}
+                + real first-sub-map photo <img> nodes even before the React
+                islands hydrate. Hidden, so it has no layout impact. */}
             <section class="sr-only">
               <h2>{seoSummaryName}</h2>
               <p>{seoDescription}</p>
-              {initialPhotos.length > 0 && (
+              {initialPhotoSeoImages.length > 0 && (
                 <Fragment>
                   <h3>{t.venue.seoSeatListLabel}</h3>
                   <ul>
-                    {initialPhotos.map((p) => {
-                      const date = performanceDate(p.performanceDate, locale);
-                      const extra = [p.eventName, date]
-                        .filter(Boolean)
-                        .join(" · ");
-                      return (
-                        <li>
-                          {extra ? `${p.seatLabel} — ${extra}` : p.seatLabel}
-                        </li>
-                      );
-                    })}
+                    {initialPhotoSeoImages.map((image) => (
+                      <li>
+                        <img
+                          src={image.contentUrl}
+                          alt={image.alt}
+                          width={image.width}
+                          height={image.height}
+                          loading="lazy"
+                          decoding="async"
+                        />
+                        <span>{image.caption}</span>
+                      </li>
+                    ))}
                   </ul>
                 </Fragment>
               )}

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -20,7 +20,7 @@ import { getMessages, venueName, subMapLabel } from "@/i18n";
 import { getVenue } from "@/data/venues";
 import { getPrefecture, prefectureName } from "@/data/prefectures";
 import { fillTemplate, performanceDate } from "@/lib/format";
-import { musicVenueLd, breadcrumbLd } from "@/lib/seo/jsonld";
+import { musicVenueLd, breadcrumbLd, venuePhotosLd } from "@/lib/seo/jsonld";
 import { readSubMapFromUrl, resolveInitialSubMapId } from "@/lib/submap";
 import { readPhotoIdFromUrl } from "@/lib/share";
 import { STORAGE_KEYS } from "@/lib/storage";
@@ -33,6 +33,7 @@ import {
   listVenuePhotoCounts,
 } from "@/server/photos";
 import { getRatingSummary } from "@/server/ratings";
+import { imageKeyToUrl } from "@/lib/photos";
 import type { PhotoDto, VenuePhotoCountsDto } from "@/lib/photos";
 import { emptyRatingSums, type VenueRatingSummaryDto } from "@/lib/venue-rating";
 
@@ -177,12 +178,34 @@ const giscusBacklink = venue
   ? new URL(`/${locale}/v/${venue.id}`, siteUrl).href
   : undefined;
 
-// Structured data (R2.2): MusicVenue + BreadcrumbList, injected into <head>.
+// Seat-view photos as crawler-readable ImageObject metadata (SEO C2). The photo
+// grid hydrates client-side, so this gives image search an explicit URL +
+// caption + license per initial-sub-map photo without relying on JS rendering.
+// Captions reuse the user-authored seat label + event/date verbatim (R9.5).
+const r2BaseUrl = import.meta.env.PUBLIC_R2_BASE_URL;
+const photoImages = initialPhotos.map((p) => {
+  const date = performanceDate(p.performanceDate, locale);
+  const extra = [p.eventName, date].filter(Boolean).join(" · ");
+  return {
+    contentUrl: imageKeyToUrl(p.imageKey, r2BaseUrl),
+    caption: extra ? `${p.seatLabel} — ${extra}` : p.seatLabel,
+    width: p.width,
+    height: p.height,
+  };
+});
+
+// Structured data (R2.2): MusicVenue + BreadcrumbList (+ ImageGallery when the
+// initial sub-map has photos), injected into <head>.
 const jsonLd = venue
   ? [
       musicVenueLd(venue, prefecture, locale, siteUrl, ratingSummary),
       breadcrumbLd(venue, prefecture, locale, siteUrl, t.nav.home),
-    ]
+      venuePhotosLd(
+        venueName(venue, locale),
+        new URL(`/${locale}/v/${venue.id}`, siteUrl).href,
+        photoImages,
+      ),
+    ].filter((ld): ld is Record<string, unknown> => ld !== null)
   : [];
 ---
 

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -30,7 +30,6 @@ Every route is locale-prefixed, e.g. ${url("/zh/v/k-arena-yokohama")}.
 
 ## Key pages
 - Home / intro: ${url("/zh/")}
-- Suggest a venue (staging): ${url("/zh/staging")}
 - Friend links: ${url("/zh/links")}
 - Privacy: ${url("/zh/privacy")}
 - Terms: ${url("/zh/terms")}

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -14,7 +14,7 @@ export const GET: APIRoute = ({ request }) => {
   const url = (path: string) => new URL(path, siteUrl).href;
 
   const venueLines = venues
-    .map((v) => `- ${v.name_zh} / ${v.name_romaji}: ${url(`/zh/v/${v.id}`)}`)
+    .map((v) => `- [${v.name_zh} / ${v.name_romaji}](${url(`/zh/v/${v.id}`)})`)
     .join("\n");
 
   const body = `# SeatView
@@ -29,11 +29,11 @@ Languages: Simplified Chinese (zh, default), Japanese (ja), English (en), Korean
 Every route is locale-prefixed, e.g. ${url("/zh/v/k-arena-yokohama")}.
 
 ## Key pages
-- Home / intro: ${url("/zh/")}
-- Friend links: ${url("/zh/links")}
-- Privacy: ${url("/zh/privacy")}
-- Terms: ${url("/zh/terms")}
-- Sitemap: ${url("/sitemap.xml")}
+- [Home / intro](${url("/zh/")})
+- [Friend links](${url("/zh/links")})
+- [Privacy](${url("/zh/privacy")})
+- [Terms](${url("/zh/terms")})
+- [Sitemap](${url("/sitemap.xml")})
 
 ## Venues (${venues.length})
 ${venueLines}

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -33,6 +33,12 @@ export const GET: APIRoute = ({ request }) => {
 
   const restPaths = [...STATIC_PATHS, ...venues.map((v) => `/v/${v.id}`)];
 
+  // Site-wide deploy timestamp (build-time, inlined via Vite `define`). The
+  // sitemap is intentionally D1-free, so we can't surface per-venue photo
+  // freshness here; <lastmod> signals "last redeploy" and is stable across
+  // requests within a deploy.
+  const lastmod = xmlEscape(__BUILD_TIME__);
+
   const urls: string[] = [];
   for (const rest of restPaths) {
     // Pre-compute the alternate set once per path (same for every locale entry).
@@ -50,7 +56,9 @@ export const GET: APIRoute = ({ request }) => {
 
     for (const loc of locales) {
       const lofrom = xmlEscape(new URL(localePath(loc, rest), siteUrl).href);
-      urls.push(`<url><loc>${lofrom}</loc>${links}</url>`);
+      urls.push(
+        `<url><loc>${lofrom}</loc><lastmod>${lastmod}</lastmod>${links}</url>`,
+      );
     }
   }
 


### PR DESCRIPTION
SEO audit follow-up — three batches from `/seo-audit`, combined into one PR
(B and C touch the same JSON-LD files, so one branch avoids merge conflicts).

The site's SEO foundation was already strong (hreflang + self-reference,
self-canonical that strips query params, locale-aware sitemap, SSR JSON-LD,
llms.txt). These are additive improvements — no existing strengths changed.

## A — sitemap freshness + index-signal consistency
- `sitemap.xml`: emit `<lastmod>` per URL from a build-time constant
  (`__BUILD_TIME__`, inlined via Vite `define`). Keeps the sitemap D1-free;
  signals "last deploy" (no per-venue timestamp exists in the static data).
- `Layout`: optional `noindex` prop → `<meta robots noindex,follow>`, and
  skip hreflang on noindex pages (they advertise an indexable cluster).
- Apply `noindex` to `/staging` (low-value UGC) and `/admin` (gated); drop
  `/staging` from `llms.txt` so sitemap + llms.txt + page meta agree.

## B — MusicVenue aggregateRating
- The venue page already SSR-reads a rating aggregate; project it to a
  schema.org `AggregateRating` (overall 4-dimension average, 1..5).
- Gated by `AGGREGATE_RATING_MIN_COUNT = 5`: below the threshold no
  `aggregateRating` is emitted (avoids "1 rating = 5 stars" noise). Reuses
  the existing `ratingOverallAverage` so it matches the on-page display.

## C — venue photo ImageGallery
- The photo grid hydrates client-side, so seat photos reach image search
  only via rendered DOM. Emit an `ImageGallery` of `ImageObject`s for the
  SSR'd initial-sub-map photos: `contentUrl`, caption (user-authored seat
  label + event/date, verbatim), dimensions, CC BY-NC 4.0 license. Capped
  at 30; no new D1 query.

## Verification
- `npm run test` — 34 pass (added hreflang-free builder + threshold +
  gallery coverage)
- `npm run typecheck` — 0 errors
- `npm run build` — clean; `<lastmod>`, `AggregateRating`, `ImageGallery`
  confirmed in the build output
- Recommend a post-deploy Google Rich Results Test on a venue page.

Planning artifacts: `.trellis/tasks/06-24-seo-optimization` (parent) +
three child tasks.
