### PR TITLE
refactor(transport): drop unused deps, dedupe client error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@giscus/react": "^3.1.0",
         "astro": "^6.4.8",
         "browser-image-compression": "^2.0.2",
-        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.0",
         "fuse.js": "^7.4.2",
@@ -25,7 +24,6 @@
         "react-photo-album": "^3.0.2",
         "react-zoom-pan-pinch": "^4.0.3",
         "tailwind-merge": "^3.6.0",
-        "tailwindcss-animate": "^1.0.7",
         "yet-another-react-lightbox": "^3.21.0"
       },
       "devDependencies": {
@@ -4266,18 +4264,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/class-variance-authority": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmmirror.com/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
-      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "clsx": "^2.1.1"
-      },
-      "funding": {
-        "url": "https://polar.sh/cva"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmmirror.com/cliui/-/cliui-8.0.1.tgz",
@@ -8223,16 +8209,8 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmmirror.com/tailwindcss/-/tailwindcss-4.3.1.tgz",
       "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tailwindcss-animate": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmmirror.com/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
-      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders"
-      }
     },
     "node_modules/tapable": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@giscus/react": "^3.1.0",
     "astro": "^6.4.8",
     "browser-image-compression": "^2.0.2",
-    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.0",
     "fuse.js": "^7.4.2",
@@ -43,7 +42,6 @@
     "react-photo-album": "^3.0.2",
     "react-zoom-pan-pinch": "^4.0.3",
     "tailwind-merge": "^3.6.0",
-    "tailwindcss-animate": "^1.0.7",
     "yet-another-react-lightbox": "^3.21.0"
   },
   "devDependencies": {

--- a/src/lib/photo-corrections-client.ts
+++ b/src/lib/photo-corrections-client.ts
@@ -3,26 +3,13 @@ import type {
   PhotoCorrectionRequest,
   PhotoCorrectionResponse,
 } from "@/lib/photo-corrections";
+import { TransportError, parseErrorCode } from "@/lib/transport";
 
 /** A typed transport failure the Lightbox maps to localized inline copy. */
-export class PhotoCorrectionError extends Error {
-  constructor(
-    readonly code: PhotoCorrectionErrorCode | "network",
-    readonly status?: number,
-  ) {
-    super(code);
+export class PhotoCorrectionError extends TransportError<PhotoCorrectionErrorCode> {
+  constructor(code: PhotoCorrectionErrorCode | "network", status?: number) {
+    super(code, status);
     this.name = "PhotoCorrectionError";
-  }
-}
-
-async function parseErrorCode(
-  res: Response,
-): Promise<PhotoCorrectionErrorCode | "network"> {
-  try {
-    const data = (await res.json()) as { error?: PhotoCorrectionErrorCode };
-    return data.error ?? "server_error";
-  } catch {
-    return "server_error";
   }
 }
 
@@ -50,7 +37,10 @@ export async function submitPhotoCorrection(
     throw new PhotoCorrectionError("network");
   }
   if (!res.ok) {
-    throw new PhotoCorrectionError(await parseErrorCode(res), res.status);
+    throw new PhotoCorrectionError(
+      await parseErrorCode<PhotoCorrectionErrorCode>(res),
+      res.status,
+    );
   }
   return (await res.json()) as PhotoCorrectionResponse;
 }

--- a/src/lib/staging-client.ts
+++ b/src/lib/staging-client.ts
@@ -16,26 +16,13 @@ import type {
   StagingRequest,
   StagingVoteResponse,
 } from "@/lib/staging";
+import { TransportError, parseErrorCode } from "@/lib/transport";
 
 /** A typed transport failure the form maps to localized inline copy. */
-export class StagingError extends Error {
-  constructor(
-    readonly code: StagingErrorCode | "network",
-    readonly status?: number,
-  ) {
-    super(code);
+export class StagingError extends TransportError<StagingErrorCode> {
+  constructor(code: StagingErrorCode | "network", status?: number) {
+    super(code, status);
     this.name = "StagingError";
-  }
-}
-
-async function parseErrorCode(
-  res: Response,
-): Promise<StagingErrorCode | "network"> {
-  try {
-    const data = (await res.json()) as { error?: StagingErrorCode };
-    return data.error ?? "server_error";
-  } catch {
-    return "server_error";
   }
 }
 
@@ -58,7 +45,10 @@ export async function submitStaging(
     throw new StagingError("network");
   }
   if (!res.ok) {
-    throw new StagingError(await parseErrorCode(res), res.status);
+    throw new StagingError(
+      await parseErrorCode<StagingErrorCode>(res),
+      res.status,
+    );
   }
   return (await res.json()) as StagingCreateResponse;
 }
@@ -85,7 +75,10 @@ export async function plusOneStaging(
     throw new StagingError("network");
   }
   if (!res.ok) {
-    throw new StagingError(await parseErrorCode(res), res.status);
+    throw new StagingError(
+      await parseErrorCode<StagingErrorCode>(res),
+      res.status,
+    );
   }
   return (await res.json()) as StagingVoteResponse;
 }

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -1,0 +1,37 @@
+// Shared browser-transport primitives for the API clients.
+//
+// Every *-client.ts hits a JSON API that, on failure, returns a stable
+// `{ error: <code> }` body which the island maps to localized inline copy (R9).
+// They all need the same two things: a typed Error carrying that code (+ HTTP
+// status), and a parser that pulls the code off a non-OK Response (defaulting to
+// "server_error", or "network" when the body isn't JSON). This is that one copy.
+
+/**
+ * A typed transport failure. `Code` is the client-specific error-code union;
+ * `"network"` is added for fetch/parse failures so callers map both uniformly.
+ * Subclass per client only to set a distinct `name` for `instanceof`.
+ */
+export class TransportError<Code extends string> extends Error {
+  constructor(
+    readonly code: Code | "network",
+    readonly status?: number,
+  ) {
+    super(code);
+    this.name = "TransportError";
+  }
+}
+
+/**
+ * Pull the `{ error }` code off a non-OK Response. Returns "server_error" when
+ * the body is missing/unparsable so callers always get a concrete code.
+ */
+export async function parseErrorCode<Code extends string>(
+  res: Response,
+): Promise<Code | "network"> {
+  try {
+    const data = (await res.json()) as { error?: Code };
+    return data.error ?? ("server_error" as Code);
+  } catch {
+    return "server_error" as Code;
+  }
+}

--- a/src/lib/upload-client.ts
+++ b/src/lib/upload-client.ts
@@ -19,26 +19,13 @@ import type {
   UploadErrorCode,
   UploadFields,
 } from "@/lib/upload";
+import { TransportError, parseErrorCode } from "@/lib/transport";
 
 /** A typed transport failure the Sheet maps to localized inline copy. */
-export class UploadError extends Error {
-  constructor(
-    readonly code: UploadErrorCode | "network",
-    readonly status?: number,
-  ) {
-    super(code);
+export class UploadError extends TransportError<UploadErrorCode> {
+  constructor(code: UploadErrorCode | "network", status?: number) {
+    super(code, status);
     this.name = "UploadError";
-  }
-}
-
-async function parseErrorCode(
-  res: Response,
-): Promise<UploadErrorCode | "network"> {
-  try {
-    const data = (await res.json()) as { error?: UploadErrorCode };
-    return data.error ?? "server_error";
-  } catch {
-    return "server_error";
   }
 }
 
@@ -61,7 +48,10 @@ export async function signUpload(
     throw new UploadError("network");
   }
   if (!res.ok) {
-    throw new UploadError(await parseErrorCode(res), res.status);
+    throw new UploadError(
+      await parseErrorCode<UploadErrorCode>(res),
+      res.status,
+    );
   }
   return (await res.json()) as SignResponse;
 }
@@ -105,7 +95,7 @@ export async function commitUpload(
         return (await res.json()) as CommitResponse;
       }
       // 4xx → terminal (do not retry). 5xx → retryable.
-      const code = await parseErrorCode(res);
+      const code = await parseErrorCode<UploadErrorCode>(res);
       if (res.status < 500) {
         throw new UploadError(code, res.status);
       }

--- a/src/lib/venue-rating-client.ts
+++ b/src/lib/venue-rating-client.ts
@@ -10,26 +10,13 @@ import type {
   RatingRequest,
   RatingResponse,
 } from "@/lib/venue-rating";
+import { TransportError, parseErrorCode } from "@/lib/transport";
 
 /** A typed transport failure the rating control maps to localized copy. */
-export class RatingError extends Error {
-  constructor(
-    readonly code: RatingErrorCode | "network",
-    readonly status?: number,
-  ) {
-    super(code);
+export class RatingError extends TransportError<RatingErrorCode> {
+  constructor(code: RatingErrorCode | "network", status?: number) {
+    super(code, status);
     this.name = "RatingError";
-  }
-}
-
-async function parseErrorCode(
-  res: Response,
-): Promise<RatingErrorCode | "network"> {
-  try {
-    const data = (await res.json()) as { error?: RatingErrorCode };
-    return data.error ?? "server_error";
-  } catch {
-    return "server_error";
   }
 }
 
@@ -55,7 +42,10 @@ export async function submitRating(
     throw new RatingError("network");
   }
   if (!res.ok) {
-    throw new RatingError(await parseErrorCode(res), res.status);
+    throw new RatingError(
+      await parseErrorCode<RatingErrorCode>(res),
+      res.status,
+    );
   }
   return (await res.json()) as RatingResponse;
 }


### PR DESCRIPTION
来自 ponytail-audit 的安全、高价值削减项。

## 改动

- **删依赖** `class-variance-authority` + `tailwindcss-animate`：源码无任何引用（无 `cva()` 调用、`src/components/ui/` 为空；插件未在 `global.css`/`astro.config` 加载，`animate-spin` 是 Tailwind 核心类）。
- **传输层去重**：把 4 个 client 各自重复的 `XError extends Error` + `parseErrorCode` 收敛到新文件 `src/lib/transport.ts`（泛型 `TransportError<Code>` + 共享 `parseErrorCode`）。`upload` / `staging` / `photo-corrections` / `venue-rating` 各 client 仅保留子类以维持各自的 `name` 与错误码联合类型。

## 兼容性

调用方（islands）零改动：`instanceof UploadError` 等仍成立，`.code` / `.status` / `.name` 与错误码映射行为不变。

## 验证

- `npm run typecheck` — 0 errors
- `npm test` — 34 passed
- 全仓搜索无两个依赖的残留引用

净变化：7 files, +75 / -99，-2 deps。