### PR TITLE
docs(readme): sync READMEs with SEO, lightbox, and venue changes

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -66,13 +66,14 @@ The core experience is just two steps — **tap a seat on the seating chart → 
 
 - **Browse by prefecture** — the venue tree on the left is grouped and collapsible by Japanese administrative divisions; Fuse.js client-side fuzzy search matches Chinese / Japanese / romaji aliases.
 - **Seating-chart markers** — view seat markers placed by other users on the venue's official seating chart (supports multi-layer / multi-zone tag switching); adjacent markers auto-cluster and show a count.
-- **Real-view Lightbox** — click a marker to see that seat's actual photo + seat number / text description; the Lightbox reflects the current photo as `?photo=`, and the share button copies a venue / area-aware deep link; the masonry feed below shows every submission for that venue.
+- **Real-view Lightbox** — click a marker to see that seat's actual photo + seat number / text description; a "nearby seats" strip at the bottom scrolls through same-cluster neighbors, and "locate on the seating chart" jumps back to the matching marker on the chart; the Lightbox reflects the current photo as `?photo=`, and the share button copies a venue / area-aware deep link; the masonry feed below shows every submission for that venue.
 - **Venue photo counts** — under the venue title, current-area and whole-venue photo counts stay in sync when switching seating-chart areas or after a new upload.
 - **Venue comments and ratings** — a quiet entry in the venue title area shows the overall score / rating count and opens a right drawer: anonymous four-dimension 1–5-star ratings on top (view, sound, amenities, transit; rating again changes your scores), giscus comments below, strictly mapped to `venue:<id>` and shared across locales and seating-chart tabs.
 - **Registration-free uploads** — mark (with an optional full-screen zoom mode for precise placement) → pick image → compress to WebP client-side (EXIF stripped) → two-stage HMAC-ticket submission; in-line guidance nudges you through unfinished steps, with IP rate limiting + Turnstile guarding the whole flow.
 - **Multilingual i18n** — `/zh` `/ja` `/en` `/ko` four-prefix routing; the bare root `/` auto-redirects by `Accept-Language` (zh / ja are equal tracks, while en / ko are an accessibility translation layer).
 - **Venue crowdsourcing** — +1 a venue in the in-site "venues you want to see" staging area (public vote count + daily rate limit + name dedup), or submit venue JSON directly via a GitHub PR.
 - **Maintainer admin** — `/admin` is edge-authenticated by Cloudflare Access and supports soft-deleting submissions.
+- **SEO and AI discoverability** — every page emits a canonical + four-locale hreflang (incl. `x-default`); venue pages inject `MusicVenue` (with `aggregateRating` when there are enough ratings) / `BreadcrumbList` / seat-photo `ImageGallery` structured data, and the home page injects `WebSite` / `Organization`; the site root serves `/sitemap.xml` (locale × path + hreflang alternates) and `/llms.txt` (a plain-text venue index for AI), while low-value pages (staging / admin) are marked `noindex,follow`.
 
 ## Tech Stack
 
@@ -96,6 +97,7 @@ The core experience is just two steps — **tap a seat on the seating chart → 
 | Masonry | `react-photo-album` (masonry) | |
 | Seating-chart zoom | **`react-zoom-pan-pinch` v4.0** | programmatic zoom via `setTransform` / `resetTransform` |
 | i18n | **Astro built-in i18n routing** | `/zh` `/ja` `/en` `/ko` four prefixes, bare root 302 |
+| SEO / structured data | **hand-written JSON-LD + hreflang + sitemap / llms.txt** | `src/lib/seo/` (pure functions + unit tests): canonical / four-locale hreflang / `MusicVenue`·`Breadcrumb`·`ImageGallery` JSON-LD / `/sitemap.xml` / `/llms.txt` |
 | ULID | **self-implemented** (`src/server/id.ts`) | not the `ulid` package (its `detectPrng()` throws on import under workerd) |
 
 > [!NOTE]
@@ -196,7 +198,7 @@ npm run deploy
 > The **maintainer admin** (`/admin` + `/api/admin/*`) is protected at the edge by **Cloudflare Access (Zero Trust)**: in the dashboard, Zero Trust → Access → Applications, create a self-hosted app covering `/*/admin` and `/api/admin/*`, and add an Allow → maintainer-email policy. After Access authenticates, it injects `Cf-Access-Authenticated-User-Email`, and the Worker trusts that header (`src/server/admin-auth.ts`); anonymous traffic never reaches the Worker. Production needs **no** admin env vars; **never** set `DEV_ADMIN_EMAIL` in production — that would bypass the SSO gateway.
 
 > [!NOTE]
-> This repo already ships 71 Japanese / overseas venue entries (85 seating-chart image assets under `public/seatmaps/`) + demo markers. Real production markers are written to D1 by users via the upload flow. You only need to re-run `npm run db:migrate:prod` after changing the DB schema; pure frontend changes need no migration.
+> This repo already ships 74 Japanese / overseas venue entries (90 seating-chart image assets under `public/seatmaps/`) + demo markers. Real production markers are written to D1 by users via the upload flow. You only need to re-run `npm run db:migrate:prod` after changing the DB schema; pure frontend changes need no migration.
 
 ## How It Works
 
@@ -241,6 +243,16 @@ The venue page SSR-reads the initial photos for the current sub-map and the per-
 
 Lightbox share links are photo-ULID authoritative: `/{locale}/v/{venueId}?tab=<subMapId>&photo=<photoId>`. When `?photo=` is present, the page does one primary-key lookup, confirms the photo is live and belongs to the current venue, uses the photo's own sub-map to override a stale `?tab=`, then auto-opens the Lightbox. Links that cannot resolve degrade to the normal venue page. While browsing, the Lightbox updates `?photo=` with `replaceState`, and the share button copies the current locale's short blurb + canonical link.
 
+The Lightbox also has a "nearby seats" horizontal strip at the bottom (`NearbyStrip`, thumbnails of same-cluster neighbors); tapping a thumbnail switches straight to that neighbor's photo. The "locate on the seating chart" button closes the Lightbox, marks the current photo as selected, and scrolls / highlights the matching marker back on the chart.
+
+### SEO and Structured Data / AI Discoverability
+
+`Layout.astro` emits `<link rel="canonical">` and four-locale `hreflang` (`zh-Hans` / `ja` / `en` / `ko` + `x-default`, generated by `src/lib/seo/hreflang.ts`) on every page; `description` can be overridden per page, falling back to the site tagline. Low-value or gated pages (staging, admin) pass `noindex`, which emits `<meta name="robots" content="noindex,follow">` and skips hreflang.
+
+Venue pages SSR-inject three JSON-LD blocks: `MusicVenue` (address / aliases, plus `aggregateRating` when the rating sample is large enough), `BreadcrumbList` (Home → Prefecture → Venue), and an `ImageGallery` of the venue's seat photos (each `ImageObject` with caption + CC license, giving crawlers a render-free image signal); the home page injects `WebSite` + `Organization`. The build logic lives in `src/lib/seo/jsonld-core.ts` (pure functions, with `*.test.ts`).
+
+The site root also serves two SSR endpoints, both generated from the static `venues` array with zero D1 access: `/sitemap.xml` (one `<url>` per locale × path, with full-language `xhtml:link` alternates + `x-default`, and `<lastmod>` set to the build-time stamp `__BUILD_TIME__`, changing only on redeploy) and `/llms.txt` (an [llmstxt.org](https://llmstxt.org/)-style plain-text overview + every venue's canonical zh link, for AI crawling). `public/robots.txt` allows all UAs and points to the sitemap.
+
 ### Key Implementation Trade-offs
 
 <details>
@@ -279,9 +291,9 @@ seatmap-real/
     ├── i18n/                 # locale config + copy
     ├── data/                 # venue tree + 47 prefectures
     ├── types/venue.ts        # Venue / SubMap / Photo / StagingVenue single source of truth
-    ├── lib/                  # cross-layer contracts + client utilities (including upload / staging / venue-rating / share / photo counts)
+    ├── lib/                  # cross-layer contracts + client utilities (upload / staging / venue-rating / share / photo counts / transport; SEO helpers in lib/seo)
     ├── server/               # Worker side: db / photos / staging / ratings / rate-limit / turnstile / id / admin-auth / r2
-    ├── pages/                # api/ (upload·staging·rating·admin·photos) + [lang]/ (home / venue / staging / admin / privacy / terms)
+    ├── pages/                # api/ (upload·staging·rating·admin·photos) + [lang]/ (home / venue / staging / admin / privacy / terms) + sitemap.xml / llms.txt (site-root SSR endpoints)
     └── styles/global.css     # Tailwind v4.3 + design tokens (OKLCH neutrals + vermilion accent)
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -66,13 +66,14 @@
 
 - **都道府県別ブラウズ** —— 左側の会場ツリーは日本の行政区画でグループ化・折りたたみ可能。Fuse.js のクライアントサイドあいまい検索で、中国語 / 日本語 / ローマ字のエイリアスもヒットします。
 - **座席表マーキング** —— 会場公式の座席表（複数レイヤー / 複数エリアの tag 切り替え対応）上で、他ユーザーがマークした座席ポイントを表示。隣接するポイントは自動で集約し件数を表示します。
-- **リアルビュー Lightbox** —— マーカーをクリックすると、その席の実写 + 座席番号 / テキスト説明を表示。Lightbox は現在の写真を `?photo=` として URL に反映し、共有ボタンで会場 / エリア文脈つきの deep link をコピーできます。下部のウォーターフォールでその会場の全投稿を表示します。
+- **リアルビュー Lightbox** —— マーカーをクリックすると、その席の実写 + 座席番号 / テキスト説明を表示。下部の「近くの座席」ストリップで同一クラスタの隣席を横スクロールでき、「座席表で位置を確認」で座席表上の対応するマーカーへ戻ります。Lightbox は現在の写真を `?photo=` として URL に反映し、共有ボタンで会場 / エリア文脈つきの deep link をコピーできます。下部のウォーターフォールでその会場の全投稿を表示します。
 - **会場の投稿数表示** —— 会場タイトル下に現在のエリアと会場全体の写真数を表示し、座席図エリアの切り替えや新規投稿後に即時同期します。
 - **会場コメントと評価** —— 会場タイトル付近の控えめな入口に総合点 / 評価数を表示し、右側のドロワーを開きます。上部は匿名4項目の 1〜5 星評価（見やすさ、音響、周辺の便利さ、アクセス。再評価はスコア変更）、下部は `venue:<id>` に厳密マッピングされた giscus コメントで、言語パスや座席表タブをまたいで同じ議論を共有します。
 - **登録不要の投稿** —— マーク（全画面ズームで精密に配置するモードあり）→ 画像選択 → クライアント側で WebP に圧縮（EXIF 除去）→ HMAC ticket の二段階コミット。未完了のステップはインライン案内で誘導し、全工程で IP レート制限 + Turnstile による不正対策。
 - **多言語 i18n** —— `/zh` `/ja` `/en` `/ko` の 4 プレフィックスルーティング、ルート直下 `/` は `Accept-Language` で自動リダイレクト（`zh` / `ja` は対等な二軸、`en` / `ko` はアクセシビリティのための翻訳レイヤー）。
 - **会場のクラウドソーシング** —— サイト内「見たい会場」一時置き場で +1（公開票数 + 日次レート制限 + 同名の重複排除）、または GitHub PR で会場 JSON を直接投稿。
 - **メンテナー管理画面** —— `/admin` は Cloudflare Access のエッジ認証で保護、投稿のソフト削除に対応。
+- **SEO と AI への発見性** —— すべてのページが canonical + 4 ロケールの hreflang（`x-default` を含む）を出力。会場ページは `MusicVenue`（評価が十分にある場合は `aggregateRating` 付き）/ `BreadcrumbList` / 座席写真の `ImageGallery` 構造化データを注入し、トップページは `WebSite` / `Organization` を注入します。サイトルートでは `/sitemap.xml`（ロケール × パス + hreflang の代替）と `/llms.txt`（AI 向けのプレーンテキスト会場インデックス）を配信し、価値の低いページ（一時置き場 / 管理画面）は `noindex,follow` を付与します。
 
 ## 技術スタック
 
@@ -96,6 +97,7 @@
 | ウォーターフォール | `react-photo-album`（masonry） | |
 | 座席表のズーム | **`react-zoom-pan-pinch` v4.0** | `setTransform` / `resetTransform` でプログラム的にズーム |
 | i18n | **Astro 組み込み i18n ルーティング** | `/zh` `/ja` `/en` `/ko` の 4 プレフィックス、ルート直下は 302 |
+| SEO / 構造化データ | **手書き JSON-LD + hreflang + sitemap / llms.txt** | `src/lib/seo/`（純粋関数 + 単体テスト）：canonical / 4 ロケールの hreflang / `MusicVenue`·`Breadcrumb`·`ImageGallery` JSON-LD / `/sitemap.xml` / `/llms.txt` |
 | ULID | **自前実装**（`src/server/id.ts`） | `ulid` パッケージは不使用（import 時に `detectPrng()` が workerd で例外を投げるため） |
 
 > [!NOTE]
@@ -196,7 +198,7 @@ npm run deploy
 > **メンテナー管理画面**（`/admin` + `/api/admin/*`）は **Cloudflare Access (Zero Trust)** によりエッジで保護されます：ダッシュボードの Zero Trust → Access → Applications で `/*/admin` と `/api/admin/*` をカバーする self-hosted アプリを新規作成し、Allow → メンテナーのメールアドレスの policy を 1 つ追加します。Access が認証後に `Cf-Access-Authenticated-User-Email` を注入し、Worker はそのヘッダーを信頼します（`src/server/admin-auth.ts`）。匿名トラフィックは Worker に到達しません。本番では admin の環境変数は**不要**です。本番で `DEV_ADMIN_EMAIL` を**絶対に設定しないでください**——SSO ゲートウェイを迂回してしまいます。
 
 > [!NOTE]
-> 本リポジトリには既に日本 / 一部海外の会場データ 71 件（`public/seatmaps/` 下に座席図画像 85 点）+ デモのマーカーが含まれています。本番の実際のマーカーは、ユーザーがアップロードフローを通じて D1 に書き込みます。`npm run db:migrate:prod` の再実行が必要なのは DB schema を変更したときだけで、フロントエンドのみの変更にマイグレーションは不要です。
+> 本リポジトリには既に日本 / 一部海外の会場データ 74 件（`public/seatmaps/` 下に座席図画像 90 点）+ デモのマーカーが含まれています。本番の実際のマーカーは、ユーザーがアップロードフローを通じて D1 に書き込みます。`npm run db:migrate:prod` の再実行が必要なのは DB schema を変更したときだけで、フロントエンドのみの変更にマイグレーションは不要です。
 
 ## 仕組み
 
@@ -241,6 +243,16 @@ presigned URL によるクライアント直接アップロードではなく、
 
 Lightbox の共有 URL は写真 ULID を主とします：`/{locale}/v/{venueId}?tab=<subMapId>&photo=<photoId>`。`?photo=` がある場合のみ主キー検索を行い、写真が公開状態で現在の会場に属することを確認し、写真自身の sub-map で古い `?tab=` を上書きしてから Lightbox を自動で開きます。解決できないリンクは通常の会場ページにフォールバックします。閲覧中は Lightbox が `replaceState` で `?photo=` を更新し、共有ボタンは現在の言語の短い文面 + canonical link をコピーします。
 
+Lightbox の下部には「近くの座席」の横スクロールストリップ（`NearbyStrip`、同一クラスタの隣席のサムネイル）もあり、サムネイルをタップするとその隣席の写真へ直接切り替わります。「座席表で位置を確認」ボタンは Lightbox を閉じ、現在の写真を選択状態にし、座席表上の対応するマーカーへスクロール / ハイライトして戻します。
+
+### SEO と構造化データ / AI への発見性
+
+`Layout.astro` はすべてのページで `<link rel="canonical">` と 4 ロケールの hreflang（`zh-Hans` / `ja` / `en` / `ko` + `x-default`、`src/lib/seo/hreflang.ts` が生成）を出力します。`description` はページごとに上書き可能で、未指定の場合はサイトのタグラインにフォールバックします。価値の低いページやゲート付きページ（一時置き場、管理画面）は `noindex` を渡し、`<meta name="robots" content="noindex,follow">` を出力して hreflang をスキップします。
+
+会場ページは SSR で 3 つの JSON-LD ブロックを注入します：`MusicVenue`（住所 / 別名、評価サンプルが十分に大きい場合は `aggregateRating` も）、`BreadcrumbList`（ホーム → 都道府県 → 会場）、そして会場の座席写真の `ImageGallery`（各 `ImageObject` にキャプション + CC ライセンスを付与し、レンダリング不要の画像シグナルをクローラーに提供）。トップページは `WebSite` + `Organization` を注入します。ビルドロジックは `src/lib/seo/jsonld-core.ts`（純粋関数、`*.test.ts` 付き）にあります。
+
+サイトルートはさらに 2 つの SSR エンドポイントを配信します。いずれも静的な `venues` 配列から生成され、D1 へのアクセスはありません：`/sitemap.xml`（ロケール × パスごとに 1 つの `<url>`、全言語の `xhtml:link` 代替 + `x-default` 付き、`<lastmod>` はビルド時のスタンプ `__BUILD_TIME__` を設定し、再デプロイ時のみ変化）と `/llms.txt`（[llmstxt.org](https://llmstxt.org/) スタイルのプレーンテキスト概要 + 全会場の canonical な zh リンク、AI のクロール用）。`public/robots.txt` はすべての UA を許可し、sitemap を指します。
+
 ### 主要な実装上のトレードオフ
 
 <details>
@@ -279,9 +291,9 @@ seatmap-real/
     ├── i18n/                 # locale 設定 + 文言
     ├── data/                 # 会場ツリー + 47 都道府県
     ├── types/venue.ts        # Venue / SubMap / Photo / StagingVenue の単一の真実の源
-    ├── lib/                  # レイヤー横断の契約 + クライアントユーティリティ（upload / staging / venue-rating / share / photo counts を含む）
+    ├── lib/                  # レイヤー横断の契約 + クライアントユーティリティ（upload / staging / venue-rating / share / photo counts / transport を含む。SEO ヘルパーは lib/seo）
     ├── server/               # Worker 側：db / photos / staging / ratings / rate-limit / turnstile / id / admin-auth / r2
-    ├── pages/                # api/（upload·staging·rating·admin·photos）+ [lang]/（ホーム / 会場ページ / 一時置き場 / 管理画面 / プライバシー / 利用規約）
+    ├── pages/                # api/（upload·staging·rating·admin·photos）+ [lang]/（ホーム / 会場ページ / 一時置き場 / 管理画面 / プライバシー / 利用規約）+ sitemap.xml / llms.txt（サイトルートの SSR エンドポイント）
     └── styles/global.css     # Tailwind v4.3 + デザイントークン（OKLCH ニュートラル + 朱赤アクセント）
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -66,13 +66,14 @@
 
 - **광역자치단체별 탐색** —— 왼쪽 공연장 트리는 일본 행정 구역으로 그룹화되어 접을 수 있습니다. Fuse.js 클라이언트 측 퍼지 검색으로 중국어 / 일본어 / 로마자 별칭까지 매칭됩니다.
 - **좌석도 마킹** —— 공연장 공식 좌석도(다중 레이어 / 다중 구역 tag 전환 지원) 위에서 다른 사용자가 표시한 좌석 포인트를 확인하고, 인접한 포인트는 자동으로 묶여 개수가 표시됩니다.
-- **실제 시야 Lightbox** —— 마커를 클릭하면 그 좌석의 실사 사진 + 좌석 번호 / 텍스트 설명을 볼 수 있습니다. Lightbox 는 현재 사진을 `?photo=` 로 URL에 반영하고, 공유 버튼은 공연장 / 구역 문맥이 담긴 deep link 를 복사합니다. 아래의 워터폴(masonry)에는 해당 공연장의 모든 투고가 표시됩니다.
+- **실제 시야 Lightbox** —— 마커를 클릭하면 그 좌석의 실사 사진 + 좌석 번호 / 텍스트 설명을 볼 수 있습니다. 아래쪽의 「인접 좌석」 띠를 스크롤하면 같은 클러스터의 이웃 좌석을 둘러볼 수 있고, 「좌석도에서 위치 찾기」 는 좌석도의 해당 마커로 다시 점프합니다. Lightbox 는 현재 사진을 `?photo=` 로 URL에 반영하고, 공유 버튼은 공연장 / 구역 문맥이 담긴 deep link 를 복사합니다. 아래의 워터폴(masonry)에는 해당 공연장의 모든 투고가 표시됩니다.
 - **공연장 사진 수 표시** —— 공연장 제목 아래에 현재 구역과 전체 공연장의 사진 수를 표시하며, 좌석도 구역 전환이나 새 업로드 후 즉시 동기화됩니다.
 - **공연장 댓글과 평점** —— 공연장 제목 영역의 조용한 진입점에 종합 점수 / 평점 수를 표시하고 오른쪽 드로어를 엽니다. 위쪽은 익명 네 항목 1~5점 별점(시야, 소리, 주변 편의, 교통. 다시 평가하면 점수 변경), 아래쪽은 `venue:<id>` 에 엄격하게 매핑된 giscus 댓글이며, 언어 경로와 좌석도 탭을 넘어 같은 토론을 공유합니다.
 - **회원 가입 없는 업로드** —— 마킹(전체 화면 줌으로 정밀하게 배치하는 모드 제공) → 이미지 선택 → 클라이언트 측에서 WebP 로 압축(EXIF 제거) → HMAC ticket 의 2단계 제출. 완료되지 않은 단계는 인라인 안내로 유도하며, 전 과정에 IP 요청 빈도 제한 + Turnstile 남용 방지가 적용됩니다.
 - **다국어 i18n** —— `/zh` `/ja` `/en` `/ko` 4개 프리픽스 라우팅, 루트 직하 `/` 는 `Accept-Language` 에 따라 자동 리다이렉트(`zh` / `ja` 는 대등한 두 축이며, `en` / `ko` 는 접근성을 위한 번역 레이어).
 - **공연장 크라우드소싱** —— 사이트 내 「보고 싶은 공연장」 임시 보관 영역에서 +1(공개 득표 수 + 일일 요청 제한 + 동명 중복 제거)하거나, GitHub PR 로 공연장 JSON 을 직접 제출할 수 있습니다.
 - **메인테이너 관리자** —— `/admin` 은 Cloudflare Access 의 엣지 인증으로 보호되며, 투고의 소프트 삭제를 지원합니다.
+- **SEO 와 AI 발견 가능성** —— 모든 페이지는 canonical + 4개 로케일 hreflang(`x-default` 포함)을 내보냅니다. 공연장 페이지는 `MusicVenue`(평점이 충분할 때 `aggregateRating` 포함) / `BreadcrumbList` / 좌석 사진 `ImageGallery` 구조화 데이터를 주입하고, 홈페이지는 `WebSite` / `Organization` 을 주입합니다. 사이트 루트는 `/sitemap.xml`(로케일 × 경로 + hreflang 대체 링크)과 `/llms.txt`(AI 용 플레인 텍스트 공연장 인덱스)를 제공하며, 가치가 낮은 페이지(임시 보관 / 관리자)는 `noindex,follow` 로 표시됩니다.
 
 ## 기술 스택
 
@@ -96,6 +97,7 @@
 | 워터폴 | `react-photo-album`(masonry) | |
 | 좌석도 줌 | **`react-zoom-pan-pinch` v4.0** | `setTransform` / `resetTransform` 으로 프로그래밍 방식 줌 |
 | i18n | **Astro 내장 i18n 라우팅** | `/zh` `/ja` `/en` `/ko` 4개 프리픽스, 루트 직하는 302 |
+| SEO / 구조화 데이터 | **수작업 JSON-LD + hreflang + sitemap / llms.txt** | `src/lib/seo/`(순수 함수 + 단위 테스트): canonical / 4개 로케일 hreflang / `MusicVenue`·`Breadcrumb`·`ImageGallery` JSON-LD / `/sitemap.xml` / `/llms.txt` |
 | ULID | **자체 구현**(`src/server/id.ts`) | `ulid` 패키지는 사용하지 않음(import 시 `detectPrng()` 가 workerd 에서 예외를 던지기 때문) |
 
 > [!NOTE]
@@ -196,7 +198,7 @@ npm run deploy
 > **메인테이너 관리자**(`/admin` + `/api/admin/*`)는 **Cloudflare Access (Zero Trust)** 에 의해 엣지에서 보호됩니다: 대시보드의 Zero Trust → Access → Applications 에서 `/*/admin` 과 `/api/admin/*` 를 포함하는 self-hosted 애플리케이션을 새로 만들고, Allow → 메인테이너 이메일의 policy 를 하나 추가하세요. Access 가 인증 후 `Cf-Access-Authenticated-User-Email` 을 주입하면 Worker 는 그 헤더를 신뢰합니다(`src/server/admin-auth.ts`). 익명 트래픽은 Worker 에 도달하지 못합니다. 프로덕션에서는 admin 환경 변수가 **필요 없습니다**. 프로덕션에서 `DEV_ADMIN_EMAIL` 을 **절대 설정하지 마세요** —— 그렇게 하면 SSO 게이트웨이를 우회하게 됩니다.
 
 > [!NOTE]
-> 본 저장소에는 이미 일본 / 일부 해외 공연장 항목 71개(`public/seatmaps/` 아래 좌석도 이미지 자산 85개) + demo 마커가 포함되어 있습니다. 프로덕션의 실제 마커는 사용자가 업로드 플로우를 통해 D1 에 기록합니다. `npm run db:migrate:prod` 를 다시 실행해야 하는 경우는 DB schema 를 변경했을 때뿐이며, 순수 프런트엔드 변경에는 마이그레이션이 필요 없습니다.
+> 본 저장소에는 이미 일본 / 일부 해외 공연장 항목 74개(`public/seatmaps/` 아래 좌석도 이미지 자산 90개) + demo 마커가 포함되어 있습니다. 프로덕션의 실제 마커는 사용자가 업로드 플로우를 통해 D1 에 기록합니다. `npm run db:migrate:prod` 를 다시 실행해야 하는 경우는 DB schema 를 변경했을 때뿐이며, 순수 프런트엔드 변경에는 마이그레이션이 필요 없습니다.
 
 ## 작동 원리
 
@@ -241,6 +243,16 @@ presigned URL 을 통한 클라이언트 직접 업로드가 아니라 **sign + 
 
 Lightbox 공유 URL 은 사진 ULID 를 기준으로 합니다: `/{locale}/v/{venueId}?tab=<subMapId>&photo=<photoId>`. `?photo=` 가 있을 때만 기본 키 조회를 한 번 수행하고, 사진이 공개 상태이며 현재 공연장에 속하는지 확인한 뒤 사진 자체의 sub-map 으로 오래된 `?tab=` 을 덮어쓰고 Lightbox 를 자동으로 엽니다. 해석할 수 없는 링크는 일반 공연장 페이지로 폴백합니다. 탐색 중에는 Lightbox 가 `replaceState` 로 `?photo=` 를 갱신하고, 공유 버튼은 현재 언어의 짧은 문구 + canonical link 를 복사합니다.
 
+Lightbox 아래쪽에는 「인접 좌석」 가로 띠(`NearbyStrip`, 같은 클러스터 이웃 좌석의 썸네일)도 있습니다. 썸네일을 탭하면 그 이웃 좌석의 사진으로 바로 전환됩니다. 「좌석도에서 위치 찾기」 버튼은 Lightbox 를 닫고 현재 사진을 선택 상태로 표시한 뒤, 좌석도의 해당 마커로 다시 스크롤 / 하이라이트합니다.
+
+### SEO 와 구조화 데이터 / AI 발견 가능성
+
+`Layout.astro` 는 모든 페이지에 `<link rel="canonical">` 과 4개 로케일 hreflang(`zh-Hans` / `ja` / `en` / `ko` + `x-default`, `src/lib/seo/hreflang.ts` 가 생성)을 내보냅니다. `description` 은 페이지별로 덮어쓸 수 있으며, 없으면 사이트 태그라인으로 폴백합니다. 가치가 낮거나 게이트된 페이지(임시 보관, 관리자)는 `noindex` 를 전달하며, 이는 `<meta name="robots" content="noindex,follow">` 를 내보내고 hreflang 을 생략합니다.
+
+공연장 페이지는 SSR 에서 세 가지 JSON-LD 블록을 주입합니다: `MusicVenue`(주소 / 별칭, 평점 표본이 충분할 때 `aggregateRating` 추가), `BreadcrumbList`(홈 → 광역자치단체 → 공연장), 그리고 공연장 좌석 사진의 `ImageGallery`(각 `ImageObject` 에 캡션 + CC 라이선스를 담아 크롤러에 렌더링 없는 이미지 신호를 제공). 홈페이지는 `WebSite` + `Organization` 을 주입합니다. 빌드 로직은 `src/lib/seo/jsonld-core.ts`(순수 함수, `*.test.ts` 포함)에 있습니다.
+
+사이트 루트는 또한 두 개의 SSR 엔드포인트를 제공하며, 둘 다 정적 `venues` 배열에서 D1 접근 없이 생성됩니다: `/sitemap.xml`(로케일 × 경로마다 하나의 `<url>`, 전체 언어 `xhtml:link` 대체 링크 + `x-default`, 그리고 빌드 시점 스탬프 `__BUILD_TIME__` 로 설정된 `<lastmod>` 는 재배포 때만 변경)과 `/llms.txt`([llmstxt.org](https://llmstxt.org/) 스타일의 플레인 텍스트 개요 + 모든 공연장의 canonical zh 링크, AI 크롤링용)입니다. `public/robots.txt` 는 모든 UA 를 허용하고 sitemap 을 가리킵니다.
+
 ### 핵심 구현 선택
 
 <details>
@@ -279,9 +291,9 @@ seatmap-real/
     ├── i18n/                 # locale 설정 + 문구
     ├── data/                 # 공연장 트리 + 47개 광역자치단체
     ├── types/venue.ts        # Venue / SubMap / Photo / StagingVenue 단일 진실 공급원
-    ├── lib/                  # 레이어 간 계약 + 클라이언트 유틸리티(upload / staging / venue-rating / share / photo counts 포함)
+    ├── lib/                  # 레이어 간 계약 + 클라이언트 유틸리티(upload / staging / venue-rating / share / photo counts / transport 포함; SEO 헬퍼는 lib/seo)
     ├── server/               # Worker 측: db / photos / staging / ratings / rate-limit / turnstile / id / admin-auth / r2
-    ├── pages/                # api/(upload·staging·rating·admin·photos) + [lang]/(홈 / 공연장 페이지 / 임시 보관 영역 / 관리자 / 개인정보 / 이용약관)
+    ├── pages/                # api/(upload·staging·rating·admin·photos) + [lang]/(홈 / 공연장 페이지 / 임시 보관 영역 / 관리자 / 개인정보 / 이용약관) + sitemap.xml / llms.txt(사이트 루트 SSR 엔드포인트)
     └── styles/global.css     # Tailwind v4.3 + 디자인 토큰(OKLCH 중성색 + 주홍 accent)
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@
 
 - **按都道府县浏览** —— 左侧场馆树按日本行政区划分组、可折叠；Fuse.js 客户端模糊搜索，中文 / 日文 / 罗马字别名都能命中。
 - **坐席图标注** —— 在场馆官方坐席图（支持多层 / 多分区 tag 切换）上查看其他用户标注的座位点，相邻点自动聚合并显示数量。
-- **真实视角 Lightbox** —— 点标注点即可查看该座位的实拍照片 + 座位号 / 文字描述；Lightbox 会把当前照片同步到地址栏 `?photo=`，分享按钮复制带场馆 / 区域文案的深链；下方瀑布流展示该场馆的全部投稿。
+- **真实视角 Lightbox** —— 点标注点即可查看该座位的实拍照片 + 座位号 / 文字描述；底部「附近座位」预览条可横滑切换同簇邻座，「在坐席图中定位」一键跳回坐席图上对应标注点；Lightbox 会把当前照片同步到地址栏 `?photo=`，分享按钮复制带场馆 / 区域文案的深链；下方瀑布流展示该场馆的全部投稿。
 - **场馆投稿统计** —— 场馆标题下方显示当前区域与全场馆照片数，切换坐席图分区或新上传后即时更新。
 - **场馆评论与评分** —— 场馆页标题区的轻量入口显示综合分 / 评分数并打开右侧抽屉：上方是匿名四项 1–5 星评分（视野、声音、周边便利、交通便利，再次评分会改分），下方是按 `venue:<id>` 严格映射的 giscus 评论，跨语言与子坐席图共享同一讨论。
 - **免注册上传** —— 标点（可进全屏放大精修）→ 选图 → 客户端压成 WebP（去 EXIF）→ HMAC ticket 两段式提交；未完成步骤有行内引导，全程 IP 限频 + Turnstile 防滥用。
 - **多语 i18n** —— `/zh` `/ja` `/en` `/ko` 四前缀路由，裸根 `/` 按 `Accept-Language` 自动重定向（`zh`/`ja` 等价双轨，`en`/`ko` 为可达性翻译层）。
 - **场馆众包** —— 站内「想看的场馆」暂存区可 +1 附议（公开票数 + 每日限流 + 同名去重），或通过 GitHub PR 直接提交场馆 JSON。
 - **维护者后台** —— `/admin` 由 Cloudflare Access 边缘鉴权，支持软删除投稿。
+- **SEO 与 AI 可发现性** —— 每页输出 canonical + 四语 hreflang（含 `x-default`）；场馆页注入 `MusicVenue`（评分样本充足时附 `aggregateRating`）/ `BreadcrumbList` / 座位照片 `ImageGallery` 结构化数据，首页注入 `WebSite` / `Organization`；站点根提供 `/sitemap.xml`（locale × 路径 + hreflang 备选）与 `/llms.txt`（面向 AI 的纯文本场馆索引），低价值页（暂存区 / 后台）标 `noindex,follow`。
 
 ## 技术栈
 
@@ -96,6 +97,7 @@
 | 瀑布流 | `react-photo-album`（masonry） | |
 | 坐席图缩放 | **`react-zoom-pan-pinch` v4.0** | 用 `setTransform` / `resetTransform` 程序化缩放 |
 | i18n | **Astro 内置 i18n 路由** | `/zh` `/ja` `/en` `/ko` 四前缀，裸根 302 |
+| SEO / 结构化数据 | **手写 JSON-LD + hreflang + sitemap / llms.txt** | `src/lib/seo/`（纯函数 + 单测）：canonical / 四语 hreflang / `MusicVenue`·`Breadcrumb`·`ImageGallery` JSON-LD / `/sitemap.xml` / `/llms.txt` |
 | ULID | **自实现**（`src/server/id.ts`） | 不用 `ulid` 包（它 import 时 `detectPrng()` 在 workerd 抛错） |
 
 > [!NOTE]
@@ -196,7 +198,7 @@ npm run deploy
 > **维护者后台**（`/admin` + `/api/admin/*`）由 **Cloudflare Access (Zero Trust)** 在边缘保护：在控制台 Zero Trust → Access → Applications 新建 self-hosted 应用覆盖 `/*/admin` 与 `/api/admin/*`，加一条 Allow → 维护者邮箱的 policy。Access 鉴权后注入 `Cf-Access-Authenticated-User-Email`，Worker 信任该头（`src/server/admin-auth.ts`），匿名流量到不了 Worker。生产**无需**任何 admin 环境变量；**切勿**在生产设 `DEV_ADMIN_EMAIL`——那会绕过 SSO 网关。
 
 > [!NOTE]
-> 本仓库已带 71 个日本 / 海外场馆条目（`public/seatmaps/` 下 85 个坐席图资源）+ demo 标注。生产的真实标注由用户通过上传流程写入 D1。改了 DB schema 才需要重新跑 `npm run db:migrate:prod`；纯前端改动无需迁移。
+> 本仓库已带 74 个日本 / 海外场馆条目（`public/seatmaps/` 下 90 个坐席图资源）+ demo 标注。生产的真实标注由用户通过上传流程写入 D1。改了 DB schema 才需要重新跑 `npm run db:migrate:prod`；纯前端改动无需迁移。
 
 ## 工作原理
 
@@ -241,6 +243,16 @@ npm run deploy
 
 Lightbox 的分享链接以照片 ULID 为主：`/{locale}/v/{venueId}?tab=<subMapId>&photo=<photoId>`。页面只在存在 `?photo=` 时做一次主键查询，确认照片未软删除、属于当前场馆，并用照片自己的 sub-map 覆盖旧的 `?tab=` 后自动打开 Lightbox；无法解析的链接降级为普通场馆页。Lightbox 浏览时用 `replaceState` 更新 `?photo=`，分享按钮复制当前语言的短文案 + canonical link。
 
+Lightbox 底部还有一条「附近座位」横滑预览条（`NearbyStrip`，同簇邻座缩略图），点缩略图直接切到邻座照片；「在坐席图中定位」按钮则关闭 Lightbox，把当前照片设为选中并把对应标注点滚动 / 高亮回坐席图。
+
+### SEO 与结构化数据 / AI 可发现性
+
+`Layout.astro` 给每页输出 `<link rel="canonical">` 与四语 `hreflang`（`zh-Hans` / `ja` / `en` / `ko` + `x-default`，由 `src/lib/seo/hreflang.ts` 生成）；`description` 可按页覆盖，缺省回落到站点 tagline。暂存区、后台等低价值或受限页传 `noindex`，输出 `<meta name="robots" content="noindex,follow">` 并跳过 hreflang。
+
+场馆页 SSR 注入三段 JSON-LD：`MusicVenue`（地址 / 别名，评分样本充足时附 `aggregateRating`）、`BreadcrumbList`（首页 → 都道府县 → 场馆）、以及该场馆座位照片的 `ImageGallery`（逐张 `ImageObject` 带 caption 与 CC 许可，给爬虫一个无需渲染的图片信号）；首页注入 `WebSite` + `Organization`。构建逻辑集中在 `src/lib/seo/jsonld-core.ts`（纯函数，带 `*.test.ts`）。
+
+站点根另有两个 SSR 端点，均从静态 `venues` 数组生成、不碰 D1：`/sitemap.xml`（每个 locale × 路径一条 `<url>`，附全语言 `xhtml:link` 备选 + `x-default`，`<lastmod>` 用构建期时间戳 `__BUILD_TIME__`，redeploy 才变）与 `/llms.txt`（[llmstxt.org](https://llmstxt.org/) 风格的纯文本概览 + 全场馆 zh 规范链接，供 AI 抓取）。`public/robots.txt` 放行全部 UA 并指向 sitemap。
+
 ### 关键实现取舍
 
 <details>
@@ -279,9 +291,9 @@ seatmap-real/
     ├── i18n/                 # locale 配置 + 文案
     ├── data/                 # 场馆树 + 47 都道府县
     ├── types/venue.ts        # Venue / SubMap / Photo / StagingVenue 单一真源
-    ├── lib/                  # 跨层契约 + 客户端工具（含 upload / staging / venue-rating / share / photo counts）
+    ├── lib/                  # 跨层契约 + 客户端工具（upload / staging / venue-rating / share / photo counts / transport；SEO 助手见 lib/seo）
     ├── server/               # Worker 侧：db / photos / staging / ratings / rate-limit / turnstile / id / admin-auth / r2
-    ├── pages/                # api/（upload·staging·rating·admin·photos）+ [lang]/（首页 / 场馆页 / 暂存区 / 后台 / 隐私 / 条款）
+    ├── pages/                # api/（upload·staging·rating·admin·photos）+ [lang]/（首页 / 场馆页 / 暂存区 / 后台 / 隐私 / 条款）+ sitemap.xml / llms.txt（站点根 SSR 端点）
     └── styles/global.css     # Tailwind v4.3 + 设计 token（OKLCH 中性色 + 朱赤 accent）
 ```
 


### PR DESCRIPTION
## 概要

自上次 README 刷新（`4747a7c`，2026-06-21）以来代码有不少改动但文档未跟进。本 PR 把四份 README（zh/en/ja/ko）同步到当前实现。

## 改动内容

- **SEO / 结构化数据 / AI 可发现性**（新子系统 `src/lib/seo/`）—— canonical + 四语 hreflang、`MusicVenue`(+`aggregateRating`)/`BreadcrumbList`/`ImageGallery` JSON-LD、首页 `WebSite`/`Organization`、新增 `/sitemap.xml` 与 `/llms.txt` SSR 端点、暂存区 / 后台 `noindex,follow`、`robots.txt` 放行全部 UA 并指向 sitemap。
- **Lightbox** —— 「附近座位」预览条（`NearbyStrip`）与「在坐席图中定位」。
- **计数更新** —— 场馆 71→74，坐席图资源 85→90。
- **项目结构** —— 补充 `lib/seo`、`lib/transport` 与站点根 SSR 端点。

## 说明

纯文档改动，无代码 / schema 变更。四份 README 逐句对齐，已校验表格 / 代码块格式无破损。