### PR TITLE
fix(seo): real 404 for unknown venues and invalid locales, valid breadcrumb JSON-LD

### DIFF
--- a/src/lib/seo/jsonld-core.ts
+++ b/src/lib/seo/jsonld-core.ts
@@ -60,39 +60,32 @@ export interface BreadcrumbLdInput {
   homeName: string;
   venueId: string;
   venueName: string;
-  prefectureName?: string | undefined;
 }
 
-/** `BreadcrumbList`: Home → Prefecture (when known) → Venue. */
+/**
+ * `BreadcrumbList`: Home → Venue. Google requires `item` on every non-last
+ * ListItem, and prefectures have no landing page yet, so the prefecture level
+ * is omitted here (the visible breadcrumb nav still shows it). When prefecture
+ * hub pages land, the level comes back WITH an `item` URL.
+ */
 export function buildBreadcrumbLd(input: BreadcrumbLdInput): JsonLd {
-  const itemListElement: JsonLd[] = [
-    {
-      "@type": "ListItem",
-      position: 1,
-      name: input.homeName,
-      item: abs(`/${input.locale}/`, input.siteUrl),
-    },
-  ];
-
-  if (input.prefectureName) {
-    itemListElement.push({
-      "@type": "ListItem",
-      position: 2,
-      name: input.prefectureName,
-    });
-  }
-
-  itemListElement.push({
-    "@type": "ListItem",
-    position: itemListElement.length + 1,
-    name: input.venueName,
-    item: abs(`/${input.locale}/v/${input.venueId}`, input.siteUrl),
-  });
-
   return {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
-    itemListElement,
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: input.homeName,
+        item: abs(`/${input.locale}/`, input.siteUrl),
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: input.venueName,
+        item: abs(`/${input.locale}/v/${input.venueId}`, input.siteUrl),
+      },
+    ],
   };
 }
 

--- a/src/lib/seo/jsonld.test.ts
+++ b/src/lib/seo/jsonld.test.ts
@@ -75,40 +75,37 @@ describe("buildMusicVenueLd aggregateRating", () => {
 });
 
 describe("buildBreadcrumbLd", () => {
-  it("builds Home -> Prefecture -> Venue breadcrumbs when prefecture is known", () => {
-    assert.deepEqual(
-      buildBreadcrumbLd({
-        locale: "zh",
-        siteUrl: "https://seat.genchi.top",
-        homeName: "首页",
-        prefectureName: "东京都",
-        venueName: "有明竞技馆",
-        venueId: "ariake-arena",
-      }),
-      {
-        "@context": "https://schema.org",
-        "@type": "BreadcrumbList",
-        itemListElement: [
-          {
-            "@type": "ListItem",
-            position: 1,
-            name: "首页",
-            item: "https://seat.genchi.top/zh/",
-          },
-          {
-            "@type": "ListItem",
-            position: 2,
-            name: "东京都",
-          },
-          {
-            "@type": "ListItem",
-            position: 3,
-            name: "有明竞技馆",
-            item: "https://seat.genchi.top/zh/v/ariake-arena",
-          },
-        ],
-      },
-    );
+  it("builds Home -> Venue breadcrumbs where every item carries an item URL", () => {
+    const ld = buildBreadcrumbLd({
+      locale: "zh",
+      siteUrl: "https://seat.genchi.top",
+      homeName: "首页",
+      venueName: "有明竞技馆",
+      venueId: "ariake-arena",
+    });
+    assert.deepEqual(ld, {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "首页",
+          item: "https://seat.genchi.top/zh/",
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "有明竞技馆",
+          item: "https://seat.genchi.top/zh/v/ariake-arena",
+        },
+      ],
+    });
+    // Google requirement: every non-last ListItem must carry `item`.
+    const items = ld.itemListElement as Record<string, unknown>[];
+    for (const entry of items.slice(0, -1)) {
+      assert.ok("item" in entry);
+    }
   });
 });
 

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -79,10 +79,9 @@ export function venuePhotosLd(
   });
 }
 
-/** `BreadcrumbList`: Home → Prefecture (when known) → Venue. */
+/** `BreadcrumbList`: Home → Venue (prefectures have no landing page yet). */
 export function breadcrumbLd(
   venue: Venue,
-  prefecture: Prefecture | undefined,
   locale: Locale,
   siteUrl: string | URL,
   homeName: string,
@@ -93,7 +92,6 @@ export function breadcrumbLd(
     homeName,
     venueId: venue.id,
     venueName: venueName(venue, locale),
-    prefectureName: prefecture ? prefectureName(prefecture, locale) : undefined,
   });
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -18,6 +18,11 @@ function isAdminPath(pathname: string): boolean {
   return ADMIN_PAGE.test(pathname) || ADMIN_API.test(pathname);
 }
 
+// Routes that legitimately live outside the `[lang]/**` prefix. Anything else
+// whose first segment is not a supported locale is an invalid alias
+// (`/xx/`, `/foobar/v/...`) and must be a real 404, not a 200/redirect.
+const NON_LOCALE_PATH = /^\/(api\/|sitemap\.xml$|llms\.txt$|404\/?$|500\/?$)/;
+
 // Middleware responsibilities (run in order on every request):
 //   1. Bare root `/` → 302 to the best locale (Accept-Language, R9.2).
 //   2. Resolve the active locale from the URL prefix and expose it on
@@ -41,6 +46,14 @@ export const onRequest = defineMiddleware((context, next) => {
   const segment = pathname.split("/")[1];
   const locale = isLocale(segment) ? segment : defaultLocale;
   context.locals.locale = locale;
+
+  // Invalid locale prefix → rewrite to the 404 page (which sets status 404).
+  // No redirect: nothing legitimate links here, and a redirect would keep the
+  // infinite alias surface (`/xx/**` duplicating `/zh/**`) alive for crawlers.
+  // Static assets never reach this middleware (served by Vite/Cloudflare first).
+  if (!isLocale(segment) && !NON_LOCALE_PATH.test(pathname)) {
+    return next("/404");
+  }
 
   // Admin guard — fail closed when no maintainer identity is present.
   if (isAdminPath(pathname)) {

--- a/src/pages/[lang]/v/[venueId].astro
+++ b/src/pages/[lang]/v/[venueId].astro
@@ -45,6 +45,11 @@ const { venueId } = Astro.params;
 
 const venue = venueId ? getVenue(venueId) : undefined;
 
+// Unknown venue → real 404 status (SEO soft-404 fix). The localized
+// not-found UI below still renders; only the status code changes (same
+// pattern as src/pages/404.astro).
+if (!venue) Astro.response.status = 404;
+
 // Resolve the sub-map to show on entry (R3.2): the `?tab=` one if valid, else
 // the first sub-map. Done server-side so the title/tabs render correctly on the
 // first paint without a client round-trip.
@@ -207,7 +212,7 @@ const initialPhotoSeoImages = initialPhotos.map((p) => {
 const jsonLd = venue
   ? [
       musicVenueLd(venue, prefecture, locale, siteUrl, ratingSummary),
-      breadcrumbLd(venue, prefecture, locale, siteUrl, t.nav.home),
+      breadcrumbLd(venue, locale, siteUrl, t.nav.home),
       venuePhotosLd(
         venueName(venue, locale),
         new URL(`/${locale}/v/${venue.id}`, siteUrl).href,


### PR DESCRIPTION
## Summary

Fixes three crawl/indexing defects from the 2026-07-04 SEO audit:

- **Soft 404**: unknown venue IDs (`/zh/v/does-not-exist`) now return HTTP 404 via `Astro.response.status = 404`; the localized not-found UI is unchanged.
- **Invalid locale prefix**: any first path segment outside `zh|ja|en|ko` (e.g. `/xx/`, `/foobar/v/...`) is rewritten by middleware to the 404 page (`next("/404")`, no redirect). A `NON_LOCALE_PATH` allowlist exempts `/api/**`, `/sitemap.xml`, `/llms.txt`, `/404`, `/500`; the `/` Accept-Language 302 is unaffected.
- **BreadcrumbList JSON-LD**: dropped the prefecture level (no landing page) so it's Home → Venue and every non-last `ListItem` carries `item`, per Google's requirement. Visible breadcrumb nav unchanged; prefecture returns with an `item` URL once hub pages exist.

## Verification

- `npm test` 34/34, `astro check` clean, `format:check` clean, `npm run build` passes
- Live curl against dev server: unknown venue → 404 with localized UI; `/xx/`, `/xx/links`, `/foobar/v/k-arena-yokohama` → 404 page; `/zh/`, `/ja/v/k-arena-yokohama` → 200; `/` → 302; `/sitemap.xml`, `/llms.txt` → 200
- Venue-page JSON-LD verified: 2 `ListItem`s, both with `item`