### PR TITLE
fix(deps): bump svgo to 4.0.2 for dependabot alert #20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7462,9 +7462,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmmirror.com/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "overrides": {
     "ws": "^8.21.0",
     "vite": "^8.0.13",
+    "svgo": "^4.0.2",
     "@esbuild-kit/core-utils": {
       "esbuild": "^0.25.12"
     },


### PR DESCRIPTION
## Summary

Resolves dependabot alert #20 — [GHSA-2p49-hgcm-8545](https://github.com/svg/svgo/security/advisories/GHSA-2p49-hgcm-8545) (high).

`svgo@4.0.1` (transitive via `astro@7.0.4`) is affected by an XSS vulnerability in the `removeScripts` plugin: namespaced `<svg:script>` elements and case-variant `javascript:` URIs were left intact.

## Changes

- Add npm override `"svgo": "^4.0.2"` to `package.json` (consistent with existing overrides for `ws` / `vite` / `yaml` / `esbuild`).
- Refresh `package-lock.json`: `svgo 4.0.1 -> 4.0.2`.

## Verification

- `npm install` — changed 1 package
- `node_modules/svgo` now `4.0.2`
- `npm ls svgo` — `astro@7.0.4 └─ svgo@4.0.2`
- `npm run build` — ✅ Complete, no errors

## Notes

- svgo is a build-time tool (Astro SVG optimization); not shipped to runtime.
- GitHub should auto-dismiss alert #20 after scanning the updated lockfile.